### PR TITLE
Change the name Ramen to ODR wherever applicable

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -13,10 +13,10 @@ on:  # yamllint disable-line rule:truthy
       - '*'
 env:
   GO_VERSION: "1.15"
-  IMAGE_TAG_BASE: "quay.io/ocs-dev/ramen"
+  IMAGE_TAG_BASE: "quay.io/ocs-dev/odr"
   IMAGE_REGISTRY: "quay.io"
   IMAGE_REPOSITORY: "ocs-dev"
-  IMAGE_NAME: "ramen"
+  IMAGE_NAME: "odr"
   IMAGE_TAG: "sanity"
 defaults:
   run:

--- a/config/dr_cluster/manifests/odr/kustomization.yaml
+++ b/config/dr_cluster/manifests/odr/kustomization.yaml
@@ -1,0 +1,23 @@
+resources:
+- ../bases/ramen_dr_cluster.clusterserviceversion.yaml
+- ../../default
+- ../../samples
+- ../../../scorecard
+
+patches:
+- patch: |-
+    - op: replace
+      path: /metadata/name
+      value: odr-cluster.v0.0.0
+    - op: replace
+      path: /spec/displayName
+      value: Openshift DR Cluster Operator
+    - op: replace
+      path: /spec/description
+      value: OpenShift DR is a disaster-recovery orchestrator for stateful applications
+        across a set of peer kubernetes clusters which are deployed and managed using
+        open-cluster-management (OCM) and provides cloud-native interfaces to orchestrate
+        the life-cycle of an application's state on PersistentVolumes.
+  target:
+    kind: ClusterServiceVersion
+    name: ramen-dr-cluster.v0.0.0

--- a/config/hub/manifests/odr/kustomization.yaml
+++ b/config/hub/manifests/odr/kustomization.yaml
@@ -1,0 +1,23 @@
+resources:
+- ../bases/ramen_hub.clusterserviceversion.yaml
+- ../../default
+- ../../samples
+- ../../../scorecard
+
+patches:
+- patch: |-
+    - op: replace
+      path: /metadata/name
+      value: odr-hub.v0.0.0
+    - op: replace
+      path: /spec/displayName
+      value: Openshift DR Hub Operator
+    - op: replace
+      path: /spec/description
+      value: OpenShift DR is a disaster-recovery orchestrator for stateful applications
+        across a set of peer kubernetes clusters which are deployed and managed using
+        open-cluster-management (OCM) and provides cloud-native interfaces to orchestrate
+        the life-cycle of an application's state on PersistentVolumes.
+  target:
+    kind: ClusterServiceVersion
+    name: ramen-hub.v0.0.0


### PR DESCRIPTION
The idea is to change it only in the non functional places. We should ensure that none of the APIs are changed. The deployment names will also retain the ramen prefix.

List of things we want to change
1. Operator should be called odr-operator
1. Bundle names should be
    1. odr-hub-operator-bundle
    1. odr-cluster-operator bundle
1. Display names for the operators should be
    1. OpenShift DR Hub Operator
    1. OpenShift DR Cluster Operator
1. Description should have reference to OpenShift DR.