### PR TITLE
Add Openshift trusted CA bundles to the deployment

### DIFF
--- a/config/dr-cluster/manifests/odr/kustomization.yaml
+++ b/config/dr-cluster/manifests/odr/kustomization.yaml
@@ -4,6 +4,16 @@ resources:
 - ../../samples
 - ../../../scorecard
 
+configMapGenerator:
+- name: openshift-trusted-cabundle
+  options:
+    disableNameSuffixHash: true
+    labels:
+      config.openshift.io/inject-trusted-cabundle: "true"
+
+patchesStrategicMerge:
+- manager_openshift_trusted_cabundle.yaml
+
 patches:
 - patch: |-
     - op: add

--- a/config/dr-cluster/manifests/odr/manager_openshift_trusted_cabundle.yaml
+++ b/config/dr-cluster/manifests/odr/manager_openshift_trusted_cabundle.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - name: ramen-manager-trustedca-vol
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
+      volumes:
+      - name: ramen-manager-trustedca-vol
+        configMap:
+          name: openshift-trusted-cabundle
+          items:
+            - key: ca-bundle.crt 
+              path: tls-ca-bundle.pem

--- a/config/hub/manifests/odr/kustomization.yaml
+++ b/config/hub/manifests/odr/kustomization.yaml
@@ -4,6 +4,16 @@ resources:
 - ../../samples
 - ../../../scorecard
 
+configMapGenerator:
+- name: openshift-trusted-cabundle
+  options:
+    disableNameSuffixHash: true
+    labels:
+      config.openshift.io/inject-trusted-cabundle: "true"
+
+patchesStrategicMerge:
+- manager_openshift_trusted_cabundle.yaml
+
 patches:
 - patch: |-
     - op: add

--- a/config/hub/manifests/odr/manager_openshift_trusted_cabundle.yaml
+++ b/config/hub/manifests/odr/manager_openshift_trusted_cabundle.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - name: ramen-manager-trustedca-vol
+          mountPath: /etc/pki/ca-trust/extracted/pem
+          readOnly: true
+      volumes:
+      - name: ramen-manager-trustedca-vol
+        configMap:
+          name: openshift-trusted-cabundle
+          items:
+            - key: ca-bundle.crt 
+              path: tls-ca-bundle.pem


### PR DESCRIPTION
- Add a empty generated config map
- Patch the deployment to use the config map

Added only to downstream branch, as this is Openshift
specific.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>