### PR TITLE
Bug 2058207: Add OCM backup label to DRPolicy resources

### DIFF
--- a/config/samples/ramendr_v1alpha1_drpolicy.yaml
+++ b/config/samples/ramendr_v1alpha1_drpolicy.yaml
@@ -9,6 +9,8 @@ spec:
       class: ramen
   drClusterSet:
     - name: east
+      region: east
       s3ProfileName: s3-profile-of-east
     - name: west
+      region: west
       s3ProfileName: s3-profile-of-west

--- a/config/samples/ramendr_v1alpha1_volumereplicationgroup.yaml
+++ b/config/samples/ramendr_v1alpha1_volumereplicationgroup.yaml
@@ -6,11 +6,13 @@ spec:
   pvcSelector:
     matchLabels:
       any-pvc-label: value
-  schedulingInterval: "1h"
   replicationState: "Primary"
-  replicationSelector:
-    matchLabels:
-      class: ramen
   s3ProfileNames:
     - s3-profile-of-east
     - s3-profile-of-west
+  async:
+    mode: Enabled
+    schedulingInterval: "10m"
+    replicationSelector:
+      matchLabels:
+        class: ramen

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -390,32 +390,20 @@ func clearDRPCStatus() {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func createNamespaces() {
-	eastNamespaceLookupKey := types.NamespacedName{Name: eastManagedClusterNamespace.Name}
-	eastNamespaceObj := &corev1.Namespace{}
+func createNamespace(ns *corev1.Namespace) {
+	nsName := types.NamespacedName{Name: ns.Name}
 
-	err := k8sClient.Get(context.TODO(), eastNamespaceLookupKey, eastNamespaceObj)
+	err := k8sClient.Get(context.TODO(), nsName, &corev1.Namespace{})
 	if err != nil {
-		Expect(k8sClient.Create(context.TODO(), eastManagedClusterNamespace)).NotTo(HaveOccurred(),
-			"failed to create east managed cluster namespace")
+		Expect(k8sClient.Create(context.TODO(), ns)).NotTo(HaveOccurred(),
+			"failed to create %v managed cluster namespace", ns.Name)
 	}
+}
 
-	westNamespaceLookupKey := types.NamespacedName{Name: westManagedClusterNamespace.Name}
-	westNamespaceObj := &corev1.Namespace{}
-
-	err = k8sClient.Get(context.TODO(), westNamespaceLookupKey, westNamespaceObj)
-	if err != nil {
-		Expect(k8sClient.Create(context.TODO(), westManagedClusterNamespace)).NotTo(HaveOccurred(),
-			"failed to create west managed cluster namespace")
-	}
-
-	appNamespaceLookupKey := types.NamespacedName{Name: appNamespace.Name}
-	appNamespaceObj := &corev1.Namespace{}
-
-	err = k8sClient.Get(context.TODO(), appNamespaceLookupKey, appNamespaceObj)
-	if err != nil {
-		Expect(k8sClient.Create(context.TODO(), appNamespace)).NotTo(HaveOccurred(), "failed to create app namespace")
-	}
+func createNamespacesAsync() {
+	createNamespace(eastManagedClusterNamespace)
+	createNamespace(westManagedClusterNamespace)
+	createNamespace(appNamespace)
 }
 
 func createManagedClusters() {
@@ -598,7 +586,7 @@ func waitForVRGMWDeletion(clusterNamespace string) {
 
 func InitialDeployment(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
 	*rmn.DRPlacementControl) {
-	createNamespaces()
+	createNamespacesAsync()
 
 	createManagedClusters()
 	createDRPolicy()

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -816,7 +816,7 @@ func recoverToFailoverCluster(userPlacementRule *plrv1.PlacementRule) {
 
 // +kubebuilder:docs-gen:collapse=Imports
 var _ = Describe("DRPlacementControl Reconciler", func() {
-	Context("DRPlacementControl Reconciler", func() {
+	Context("DRPlacementControl Reconciler Async DR", func() {
 		userPlacementRule := &plrv1.PlacementRule{}
 		drpc := &rmn.DRPlacementControl{}
 		When("An Application is deployed for the first time", func() {

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -63,7 +63,7 @@ var (
 			Name: West1ManagedCluster,
 			Labels: map[string]string{
 				"name": West1ManagedCluster,
-				"key1": "value1",
+				"key1": "west1",
 			},
 		},
 	}
@@ -72,7 +72,7 @@ var (
 			Name: East1ManagedCluster,
 			Labels: map[string]string{
 				"name": East1ManagedCluster,
-				"key1": "value2",
+				"key1": "east1",
 			},
 		},
 	}
@@ -250,7 +250,7 @@ func createPlacementRule(name, namespace string) *plrv1.PlacementRule {
 	namereq.Key = "key1"
 	namereq.Operator = metav1.LabelSelectorOpIn
 
-	namereq.Values = []string{"value1"}
+	namereq.Values = []string{"west1"}
 	labelSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{namereq},
 	}

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -77,7 +77,7 @@ var (
 		},
 	}
 
-	clusters = []*spokeClusterV1.ManagedCluster{west1Cluster, east1Cluster}
+	asyncClusters = []*spokeClusterV1.ManagedCluster{west1Cluster, east1Cluster}
 
 	east1ManagedClusterNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: East1ManagedCluster},
@@ -93,7 +93,7 @@ var (
 
 	schedulingInterval = "1h"
 
-	drPolicy = &rmn.DRPolicy{
+	asyncDRPolicy = &rmn.DRPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: DRPolicyName,
 		},
@@ -406,8 +406,8 @@ func createNamespacesAsync() {
 	createNamespace(appNamespace)
 }
 
-func createManagedClusters() {
-	for _, cl := range clusters {
+func createManagedClustersAsync() {
+	for _, cl := range asyncClusters {
 		mcLookupKey := types.NamespacedName{Name: cl.Name}
 		mcObj := &spokeClusterV1.ManagedCluster{}
 
@@ -421,13 +421,13 @@ func createManagedClusters() {
 	}
 }
 
-func createDRPolicy() {
-	err := k8sClient.Create(context.TODO(), drPolicy)
+func createDRPolicyAsync() {
+	err := k8sClient.Create(context.TODO(), asyncDRPolicy)
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func deleteDRPolicy() {
-	Expect(k8sClient.Delete(context.TODO(), drPolicy)).To(Succeed())
+func deleteDRPolicyAsync() {
+	Expect(k8sClient.Delete(context.TODO(), asyncDRPolicy)).To(Succeed())
 }
 
 func moveVRGToSecondary(clusterNamespace, mwType string, protectData bool) (*rmn.VolumeReplicationGroup, error) {
@@ -584,12 +584,12 @@ func waitForVRGMWDeletion(clusterNamespace string) {
 	}, timeout, interval).Should(BeTrue(), "failed to wait for manifest deletion for type vrg")
 }
 
-func InitialDeployment(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
+func InitialDeploymentAsync(namespace, placementName, homeCluster string) (*plrv1.PlacementRule,
 	*rmn.DRPlacementControl) {
 	createNamespacesAsync()
 
-	createManagedClusters()
-	createDRPolicy()
+	createManagedClustersAsync()
+	createDRPolicyAsync()
 
 	placementRule := createPlacementRule(placementName, namespace)
 	drpc := createDRPC(DRPCName, DRPCNamespaceName)

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The RamenDR authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	OCMBackupLabelKey   string = "cluster.open-cluster-management.io/backup"
+	OCMBackupLabelValue string = "resource"
+)
+
+func AddLabel(meta *metav1.ObjectMeta, key, value string) (bool, map[string]string) {
+	const labelAdded = true
+
+	labels := meta.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	if _, ok := labels[key]; !ok {
+		labels[key] = value
+
+		return labelAdded, labels
+	}
+
+	return !labelAdded, nil
+}
+
+func AddFinalizer(obj client.Object, finalizer string) bool {
+	const finalizerAdded = true
+
+	if !controllerutil.ContainsFinalizer(obj, finalizer) {
+		controllerutil.AddFinalizer(obj, finalizer)
+
+		return finalizerAdded
+	}
+
+	return !finalizerAdded
+}

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,56 @@
+# ocm-minikube-ramen.sh
+
+Ramen end-to-end test script
+
+- can be run from any directory; writes temporary files to /tmp
+- installs some dependencies (e.g. minikube, golang, etc), but not necessarily
+  all (e.g. kvm on Linux distributions other than RHEL and Ubuntu)
+- hub cluster name is specified with the `hub_cluster_name` variable
+    - defaults to `hub`
+- managed cluster names are specified with the `spoke_cluster_names` variable
+    - `cluster1` and `hub` by default
+    - a hub may also be a managed cluster
+- takes a list of functions to execute:
+    - `deploy` (default) deploys the environment including:
+      minikube clusters, ocm, rook-ceph, minio s3 stores, olm, ramen
+        - calls `ramen_images_build_and_archive` which builds and deploys ramen
+          from the source rooted from the parent directory of the script
+            - skips the ramen manager image build if the `skip_ramen_build` variable's
+              value is something other than an empty string or `false`
+        - calls `ramen_deploy` which deploys ramen hub operator, crds, drpolicy
+          and samples channel
+    - `application_sample_deploy` deploys the busybox-sample app to 1st managed cluster
+       named
+    - `application_sample_failover` fails over the busybox-sample app to 2nd managed
+       cluster named
+    - `application_sample_relocate` relocates the busybox-sample app to 1st managed
+       cluster named
+    - `application_sample_undeploy` undeploys the busybox-sample app from the cluster
+       it was last deployed to
+    - `undeploy` undeploys the things deployed by `deploy`
+        - calls `ramen_undeploy` which undeploys the things deployed by `ramen_deploy`
+        - calls `rook_ceph_undeploy` which deletes the minikube clusters and rook-ceph
+          virsh volumes and alone can undeploy the environment quickly by skipping
+          component undeployments
+    - see source for several other routines to deploy and undeploy various copmonents
+      individually
+- is designed to be idempotent so that deploy functions can be rerun without having
+  to first undeploy
+    - one exception to this is image deployment
+        - for example, if ramen image changes, it can be deployed by undeploying
+          and redeploying ramen
+    - tip: if an error is encountered leaving something in a state such that an undeployment
+      fails, consider redeploying to get it into a known state
+
+Examples:
+
+```sh
+spoke_cluster_names=cluster1\ cluster2 ./ocm-minikube-ramen.sh
+spoke_cluster_names=cluster1\ cluster2 ./ocm-minikube-ramen.sh application_sample_deploy
+spoke_cluster_names=cluster1\ cluster2 ./ocm-minikube-ramen.sh application_sample_failover
+spoke_cluster_names=cluster1\ cluster2 ./ocm-minikube-ramen.sh application_sample_relocate
+spoke_cluster_names=cluster1\ cluster2 ./ocm-minikube-ramen.sh application_sample_undeploy
+./ocm-minikube-ramen.sh ramen_build_and_archive
+spoke_cluster_names=cluster1\ cluster2 ./ocm-minikube-ramen.sh ramen_undeploy
+spoke_cluster_names=cluster1\ cluster2 ./ocm-minikube-ramen.sh ramen_deploy
+```

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -578,8 +578,10 @@ ramen_samples_channel_and_drpolicy_deploy()
 	        value:
 	          - name: $3
 	            s3ProfileName: minio-on-$3
+	            region: east
 	          - name: $4
 	            s3ProfileName: minio-on-$4
+	            region: west
 	a
 	kubectl --context $hub_cluster_name apply -k $1
 	for cluster_name in $spoke_cluster_names; do

--- a/hack/ocm-minikube-ramen.sh
+++ b/hack/ocm-minikube-ramen.sh
@@ -408,7 +408,7 @@ ramen_deploy_hub_or_spoke()
 	kube_context_set $1
 	make -C $ramen_directory_path_name deploy-$2 IMG=$ramen_manager_image_reference
 	kube_context_set_undo
-	kubectl --context $1 -n ramen-system wait deployments --all --for condition=available --timeout 60s
+	kubectl --context $1 -n ramen-system wait deployments --all --for condition=available --timeout 2m
 	ramen_config_deploy_hub_or_spoke $1 $2
 }
 exit_stack_push unset -f ramen_deploy_hub_or_spoke
@@ -421,8 +421,8 @@ ramen_s3_secret_kubectl_cluster()
 	  name: s3secret
 	  namespace: ramen-system
 	stringData:
-	  AWS_ACCESS_KEY_ID: "minio"
-	  AWS_SECRET_ACCESS_KEY: "minio123"
+	  AWS_ACCESS_KEY_ID: minio
+	  AWS_SECRET_ACCESS_KEY: minio123
 	EOF
 }
 exit_stack_push unset -f ramen_s3_secret_kubectl_cluster

--- a/hack/ocm-minikube.sh
+++ b/hack/ocm-minikube.sh
@@ -100,7 +100,7 @@ ocm_registration_operator_image_specs()
 exit_stack_push unset -f ocm_registration_operator_image_specs
 ocm_registration_operator_kubectl()
 {
-	kubectl --context $1 $3 -k https://github.com/open-cluster-management/registration-operator/deploy/$2/config?ref=$ocm_registration_operator_git_ref
+	kubectl --context $1 $3 -k https://github.com/stolostron/registration-operator/deploy/$2/config?ref=$ocm_registration_operator_git_ref
 }
 exit_stack_push unset -f ocm_registration_operator_kubectl
 ocm_registration_operator_kustomization_directory_path_name()
@@ -114,7 +114,7 @@ ocm_registration_operator_cr_kubectl()
 	mkdir -p $8
 	cat <<-a >$8/kustomization.yaml
 	resources:
-	  - https://raw.githubusercontent.com/open-cluster-management/registration-operator/$ocm_registration_operator_git_ref/deploy/$3/config/samples/operator_open-cluster-management_$4s.cr.yaml
+	  - https://raw.githubusercontent.com/stolostron/registration-operator/$ocm_registration_operator_git_ref/deploy/$3/config/samples/operator_open-cluster-management_$4s.cr.yaml
 	patchesJson6902:
 	  - target:
 	      group: operator.open-cluster-management.io
@@ -264,7 +264,7 @@ ocm_foundation_operator_kubectl()
 	mkdir -p $2
 	cat <<-a >$2/kustomization.yaml
 	resources:
-	  - https://github.com/open-cluster-management/multicloud-operators-foundation/deploy/$1?ref=$ocm_foundation_operator_git_ref
+	  - https://github.com/stolostron/multicloud-operators-foundation/deploy/$1?ref=$ocm_foundation_operator_git_ref
 	namespace: $4
 	images:
 	  - name: quay.io/open-cluster-management/multicloud-manager
@@ -386,7 +386,7 @@ exit_stack_push unset -v subscription_operator_file_names_deploy_managed
 exit_stack_push unset -v subscription_operator_file_names_examples_helmrepo_hub_channel
 subscription_operator_file_url()
 {
-	github_url_file open-cluster-management/multicloud-operators-subscription $1 $subscription_operator_git_ref
+	github_url_file stolostron/multicloud-operators-subscription $1 $subscription_operator_git_ref
 }
 exit_stack_push unset -f subscription_operator_file_url
 subscription_operator_file_urls()
@@ -652,7 +652,7 @@ exit_stack_push unset -f ocm_application_samples_patch_apply
 ocm_application_samples_checkout()
 {
 	set -- application-samples
-	git_clone_and_checkout https://github.com/open-cluster-management $1 main 65853af
+	git_clone_and_checkout https://github.com/stolostron $1 main 65853af
 	exit_stack_push git_checkout_undo $1
 	ocm_application_samples_patch_old_undo $1
 	ocm_application_samples_patch_apply $1


### PR DESCRIPTION
Also, refactored the code a little to reuse common
functions across DRPC and DRPolicy.

Adding the label to the config map is pending, which
needs to happen once we start watching it for changes
and update dr-cluster with the new config map.

Additional cherry picks in PR is for various envtest changes that enable
better sanity testing of code, does not impact/change packaged deliverables.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>
(cherry picked from commit e5e91bf3aa75caf6f20d0c9d0ef8f2d345fb55f6)