### PR TITLE
Bug 2058220: Restrict secret OCM policy name

### DIFF
--- a/controllers/util/mw_util_test.go
+++ b/controllers/util/mw_util_test.go
@@ -301,7 +301,8 @@ var _ = Describe("IsManifestInAppliedState", func() {
 	Context("GetMetricValueFromName tests custom Prometheus metrics", func() {
 		It("basic timer functionality", func() {
 			timer := prometheus.NewTimer(prometheus.ObserverFunc(testGauge.Set))
-			timer.ObserveDuration() // stop timer when function returns (all cases)
+			time.Sleep(1 * time.Second) // let the observer gather some time
+			timer.ObserveDuration()     // stop timer when function returns (all cases)
 
 			val, err := rmnutil.GetMetricValueSingle("ramen_test_gauge", dto.MetricType_GAUGE)
 


### PR DESCRIPTION
OCM policy names are in the format namespace.name and
have a length limitation of 63 chars.

Added checks for name length and also reduced the other
resource name lengths by removing part of the prefix.

Policy will now be named with the same name as the secret.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>
(cherry picked from commit 9c812c662af7c216669a24e61924034967d38787)