### PR TITLE
Bug 2059303: Fix static strings in config map append

### DIFF
--- a/config/hub/manifests/odr/ramen_manager_config_append.yaml
+++ b/config/hub/manifests/odr/ramen_manager_config_append.yaml
@@ -1,8 +1,9 @@
 drClusterOperator:
   deploymentAutomationEnabled: true
+  s3SecretDistributionEnabled: true
   channelName: alpha
-  packageName: odr-cluster-operator
-  namespaceName: openshift-dr-system
+  packageName: ramen-dr-cluster-operator
+  namespaceName: ramen-system
   catalogSourceName: redhat-operators
   catalogSourceNamespaceName: openshift-marketplace
-  clusterServiceVersionName: odr-cluster-operator.v0.0.1
+  clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1


### PR DESCRIPTION
The bundle overlay for odr contained strings that were
already odr specific, which hence were not replaced by
the Makefile when building the bundle.

This commit rectifies this by changing the defaults to
ones that the Makefile would replace, hence fixing the
incorrect clusterServiceVersionName in the config map
that was bundled.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>