### PR TITLE
Bug 2063865: Sync mode fixes for VRG deletion in primary and secondary mode

### DIFF
--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -642,6 +642,21 @@ func (v *VRGInstance) restorePVClusterData(pvList []corev1.PersistentVolume) err
 	return nil
 }
 
+func (v *VRGInstance) updateExistingPVForSync(pv *corev1.PersistentVolume) error {
+	// In case of sync mode, the pv is never deleted as part of the
+	// failover/relocate process. Hence, the restore may not be
+	// required and the annotation for restore can be missing for
+	// the sync mode.
+	v.cleanupPVForRestore(pv)
+	v.addPVRestoreAnnotation(pv)
+
+	if err := v.reconciler.Update(v.ctx, pv); err != nil {
+		return fmt.Errorf("failed to cleanup existing PV for sync DR PV: %v, err: %w", pv.Name, err)
+	}
+
+	return nil
+}
+
 func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	existingPV := &corev1.PersistentVolume{}
 
@@ -650,16 +665,27 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 		return fmt.Errorf("failed to get existing PV (%w)", err)
 	}
 
-	if existingPV.ObjectMeta.Annotations == nil ||
-		existingPV.ObjectMeta.Annotations[PVRestoreAnnotation] == "" {
-		return fmt.Errorf("found PV object not restored by Ramen for PV %s", existingPV.Name)
+	if existingPV.ObjectMeta.Annotations != nil &&
+		existingPV.ObjectMeta.Annotations[PVRestoreAnnotation] == "True" {
+		// Should we check and see if PV in being deleted? Should we just treat it as exists
+		// and then we don't care if deletion takes place later, which is what we do now?
+		v.log.Info("PV exists and managed by Ramen", "PV", existingPV)
+
+		return nil
 	}
 
-	// Should we check and see if PV in being deleted? Should we just treat it as exists
-	// and then we don't care if deletion takes place later, which is what we do now?
-	v.log.Info("PV exists and managed by Ramen", "PV", existingPV)
+	// Right now, we can only have either Sync mode or Async mode. In case of
+	// sync mode, the pv is never deleted as part of the failover/relocate
+	// process. Hence, the restore is not required and the annotation for
+	// restore can be missing for the sync mode. Skip the check for the
+	// annotation in this case.
+	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+		v.log.Info("PV exists, will update for sync", "PV", existingPV)
 
-	return nil
+		return v.updateExistingPVForSync(existingPV)
+	}
+
+	return fmt.Errorf("found PV object not restored by Ramen for PV %s", existingPV.Name)
 }
 
 // cleanupPVForRestore cleans up required PV fields, to ensure restore succeeds to a new cluster, and

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -1304,9 +1304,17 @@ func (v *VRGInstance) preparePVCForVRDeletion(pvc *corev1.PersistentVolumeClaim,
 		return nil
 	}
 
-	// Change PV `reclaimPolicy` back to stored state
-	if err := v.undoPVRetentionForPVC(*pvc, log); err != nil {
-		return err
+	// For Async mode, we want to change the retention policy back to delete
+	// and remove the annotation.
+	// For Sync mode, we don't want to set the retention policy to delete as
+	// both the primary and the secondary VRG map to the same volume. The only
+	// state where a delete retention policy is required for the sync mode is
+	// when the VRG is primary.
+	if !(v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary &&
+		v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled) {
+		if err := v.undoPVRetentionForPVC(*pvc, log); err != nil {
+			return err
+		}
 	}
 
 	// TODO: Delete the PV from the backing store? But when is it safe to do so?

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -774,12 +774,11 @@ func (v *VRGInstance) processForDeletion() (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-// For now, for reginalDR (i.e. async mode enabled),
-// VolRep resources created by VRG have to be deletion
-// when VRG is deleted. For MetroDR (i.e. sync mode enabled)
-// nothing has to be done. So whether this VRG resource require
-// a requeue is a logical OR of whether async mode requires a
-// requeue and whether sync more requires a requeue.
+// For now, async mode and sync mode can be enabled only in either or fashion
+// and the function reconcileVRsForDeletion is capable of handling it for both.
+// However, in the future, we may want to enable both the modes at the same
+// time and might call different functions for those modes. This function is in
+// preparation of that need.
 func (v *VRGInstance) deleteVRGHandleMode() bool {
 	asyncModeRequeue := false
 	syncModeRequeue := false
@@ -788,11 +787,8 @@ func (v *VRGInstance) deleteVRGHandleMode() bool {
 		asyncModeRequeue = v.reconcileVRsForDeletion()
 	}
 
-	// for now nothing to do for MetroDR. VRG does not create VolRep or
-	// any other resource for MetroDR. Hence set syncModeRequeue to false
-	// indicating metroDR does not require a requeue.
 	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
-		syncModeRequeue = false
+		syncModeRequeue = v.reconcileVRsForDeletion()
 	}
 
 	return asyncModeRequeue || syncModeRequeue
@@ -970,6 +966,11 @@ func (v *VRGInstance) processAsPrimary() (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
+// For now, async mode and sync mode can be enabled only in either or fashion
+// and the functions reconcileVRsAsPrimary reconcileVRsAsSecondary are capable
+// of handling it for both. However, in the future, we may want to enable both
+// the modes at the same time and might call different functions for those
+// modes. This function is in preparation of that need.
 func (v *VRGInstance) handleVRGMode(state ramendrv1alpha1.ReplicationState) bool {
 	asyncNeedRequeue := false
 	syncNeedRequeue := false
@@ -985,28 +986,16 @@ func (v *VRGInstance) handleVRGMode(state ramendrv1alpha1.ReplicationState) bool
 	}
 
 	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
-		// mark all PVCs as protected.
-		v.markAllPVCsProtected()
+		if state == ramendrv1alpha1.Primary {
+			syncNeedRequeue = v.reconcileVRsAsPrimary()
+		}
 
-		syncNeedRequeue = false
+		if state == ramendrv1alpha1.Secondary {
+			syncNeedRequeue = v.reconcileVRsAsSecondary()
+		}
 	}
 
 	return asyncNeedRequeue || syncNeedRequeue
-}
-
-func (v *VRGInstance) markAllPVCsProtected() {
-	v.log.Info("marking all pvc resources ready for use and protected")
-
-	msg := "PVC in the VolumeReplicationGroup is ready for use"
-
-	for idx := range v.pvcList.Items {
-		pvc := &v.pvcList.Items[idx]
-
-		// Each protected PVC condition in VRG status has the same name
-		// as PVC. Use that.
-		v.updatePVCDataReadyCondition(pvc.Name, VRGConditionReasonReady, msg)
-		v.updatePVCDataProtectedCondition(pvc.Name, VRGConditionReasonReady, msg)
-	}
 }
 
 // reconcileVRsAsPrimary creates/updates VolumeReplication CR for each pvc
@@ -1577,13 +1566,51 @@ func (ObjectStorePVDeleter) DeletePVs(v interface{}, s3ProfileName string) (err 
 // processVRAsPrimary processes VR to change its state to primary, with the assumption that the
 // related PVC is prepared for VR protection
 func (v *VRGInstance) processVRAsPrimary(vrNamespacedName types.NamespacedName, log logr.Logger) (bool, error) {
-	return v.createOrUpdateVR(vrNamespacedName, volrep.Primary, log)
+	if v.instance.Spec.Async.Mode == ramendrv1alpha1.AsyncModeEnabled {
+		return v.createOrUpdateVR(vrNamespacedName, volrep.Primary, log)
+	}
+
+	// TODO: createOrUpdateVR does two things. It modifies the VR and also
+	// updates the PVC Conditions. For the sync mode, we only want the latter.
+	// In the future, it would be better to refactor createOrUpdateVR into two
+	// functions. For now, we are only updating the conditions for the sync
+	// mode below. As there is no VolRep involved in sync mode, the
+	// availability is always true. Also, the refactor should work for the
+	// condition where both async and sync are enabled at the same time.
+	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+		msg := "PVC in the VolumeReplicationGroup is ready for use"
+		v.updatePVCDataReadyCondition(vrNamespacedName.Name, VRGConditionReasonReady, msg)
+		v.updatePVCDataProtectedCondition(vrNamespacedName.Name, VRGConditionReasonReady, msg)
+
+		return true, nil
+	}
+
+	return true, nil
 }
 
 // processVRAsSecondary processes VR to change its state to secondary, with the assumption that the
 // related PVC is prepared for VR as secondary
 func (v *VRGInstance) processVRAsSecondary(vrNamespacedName types.NamespacedName, log logr.Logger) (bool, error) {
-	return v.createOrUpdateVR(vrNamespacedName, volrep.Secondary, log)
+	if v.instance.Spec.Async.Mode == ramendrv1alpha1.AsyncModeEnabled {
+		return v.createOrUpdateVR(vrNamespacedName, volrep.Secondary, log)
+	}
+
+	// TODO: createOrUpdateVR does two things. It modifies the VR and also
+	// updates the PVC Conditions. For the sync mode, we only want the latter.
+	// In the future, it would be better to refactor createOrUpdateVR into two
+	// functions. For now, we are only updating the conditions for the sync
+	// mode below. As there is no VolRep involved in sync mode, the
+	// availability is always true. Also, the refactor should work for the
+	// condition where both async and sync are enabled at the same time.
+	if v.instance.Spec.Sync.Mode == ramendrv1alpha1.SyncModeEnabled {
+		msg := "VolumeReplication resource for the pvc as Secondary is in sync with Primary"
+		v.updatePVCDataReadyCondition(vrNamespacedName.Name, VRGConditionReasonReplicated, msg)
+		v.updatePVCDataProtectedCondition(vrNamespacedName.Name, VRGConditionReasonDataProtected, msg)
+
+		return true, nil
+	}
+
+	return true, nil
 }
 
 // createOrUpdateVR updates an existing VR resource if found, or creates it if required


### PR DESCRIPTION
This PR has three commits, which do the following:

* Update the PVC conditions only inside the leaf functions of VRG which are ProcessAsPrimary and ProcessAsSecondary. This way the code flow for both sync and async modes is the same.
* In sync mode, the PV should not be allowed to be deleted when the VRG is deleted as secondary.
* As the PV is left behind when the VRG is deleted as secondary, when the VRG is created again, it needs to remove the claim refs on the existing PV and place the restore annotation on it.