### PR TITLE
Bug 2090685: Cache object storer for subsequent uploads

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -183,7 +183,7 @@ var _ = BeforeSuite(func() {
 		Client:         k8sManager.GetClient(),
 		APIReader:      k8sManager.GetAPIReader(),
 		Log:            ctrl.Log.WithName("controllers").WithName("VolumeReplicationGroup"),
-		ObjStoreGetter: ramencontrollers.S3ObjectStoreGetter(),
+		ObjStoreGetter: fakeObjectStoreGetter{},
 		PVDownloader:   FakePVDownloader{},
 		PVUploader:     FakePVUploader{},
 		PVDeleter:      FakePVDeleter{},

--- a/controllers/volumereplicationgroup_controller_test.go
+++ b/controllers/volumereplicationgroup_controller_test.go
@@ -1106,7 +1106,11 @@ func (s FakePVDownloader) DownloadPVs(ctx context.Context, r client.Reader,
 
 type FakePVUploader struct{}
 
-func (s FakePVUploader) UploadPV(v interface{}, s3ProfileName string, pvc *corev1.PersistentVolumeClaim) error {
+func (s FakePVUploader) UploadPV(
+	storer vrgController.ObjectStorer,
+	v interface{},
+	s3ProfileName string,
+	pvc *corev1.PersistentVolumeClaim) error {
 	UploadedPVs[pvc.Spec.VolumeName] = Empty{}
 
 	return nil


### PR DESCRIPTION
Currently for each s3 profile that the PVs need to be
uploaded to, we connect to the s3 store for each volume
that is protected by the current instance of VRG.

This causes a 2 minute slowdown in case the s3 store is
unreachable, which can happen during failover cases.

For a workload with n PVCs as a result the failover takes
n*120 seconds, which is far too long.

This is fixed by connecting to the s3 profile once per VRG
reconciliation, and using the cached connection/storer to
perform subsequent uploads or error out immediately.

Alternative: was to upload PVs post creating VRs for the same
but that would still reconcile the current VRG for n*120
seconds in the second loop, hence is dropped as an
alternative.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>