### PR TITLE
Bug 2109443: Relocate post initial deployment gets stuck

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -456,6 +456,13 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(ctx context.Context,
 		},
 	}
 
+	isMetro, _ := dRPolicySupportsMetro(drPolicy, drClusters)
+	if isMetro {
+		d.volSyncDisabled = true
+
+		r.Log.Info("volsync is set to disabled")
+	}
+
 	// Save the instance status
 	d.instance.Status.DeepCopyInto(&d.savedInstanceStatus)
 	r.Log.Info(fmt.Sprintf("PlacementRule Status is: (%+v)", usrPlRule.Status))

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -478,6 +478,13 @@ func (v *VRGInstance) validateVRGMode() error {
 }
 
 func (v *VRGInstance) restorePVs() error {
+	if v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync {
+		msg := "PV restore skipped, as VRG is orchestrating final sync"
+		setVRGClusterDataReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, msg)
+
+		return nil
+	}
+
 	clusterDataReady := findCondition(v.instance.Status.Conditions, VRGConditionTypeClusterDataReady)
 	if clusterDataReady != nil {
 		v.log.Info("ClusterDataReady condition",

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/stolostron/multicloud-operators-placementrule v1.2.4-1-20220311-8eedb3f.0.20220411162042-3de0a2f908f1
 	go.uber.org/zap v1.21.0
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
+	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8
 	k8s.io/api v0.23.6
 	k8s.io/apimachinery v0.23.6
 	k8s.io/client-go v12.0.0+incompatible
@@ -76,7 +77,6 @@ require (
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
-	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect


### PR DESCRIPTION
Final sync phase for Primary VRG is to ensure protected PV/PVCs are quiesced before their final data is synced across. This does not require a restore phase to be executed, and is hence skipped.

Further, the restore phase causes errors, as a fresh workload that is relocated, enters the final phase preparation and causes PV restore to fail, as PVs exist and are not restored by Ramen.

This is fixed by this PR, and additionally:
- Bug 2092882 ([MetroDR]: Volsync.disabled: true should be set on ramen configmap)
- Volsync changes also regressed a rapid reconciliation issue in VRG, which is fixed as a part of these changes