### PR TITLE
Bug 2123501: Replace PVC in use check with VA and pods using PVC check

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -56,7 +56,6 @@ import (
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	ramencontrollers "github.com/ramendr/ramen/controllers"
 	"github.com/ramendr/ramen/controllers/util"
-	"github.com/ramendr/ramen/controllers/volsync"
 	velero "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	// +kubebuilder:scaffold:imports
 )
@@ -297,7 +296,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Index fields that are required for VSHandler
-	err = volsync.IndexFieldsForVSHandler(context.TODO(), k8sManager.GetFieldIndexer())
+	err = util.IndexFieldsForVSHandler(context.TODO(), k8sManager.GetFieldIndexer())
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect((&ramencontrollers.DRClusterReconciler{

--- a/controllers/util/pvcs_util.go
+++ b/controllers/util/pvcs_util.go
@@ -37,8 +37,13 @@ const (
 	VolumeAttachmentToPVIndexName string = "spec.source.persistentVolumeName"
 )
 
-func ListPVCsByPVCSelector(ctx context.Context, k8sClient client.Client, pvcLabelSelector metav1.LabelSelector,
-	namespace string, volSyncDisabled bool, logger logr.Logger,
+func ListPVCsByPVCSelector(
+	ctx context.Context,
+	k8sClient client.Client,
+	logger logr.Logger,
+	pvcLabelSelector metav1.LabelSelector,
+	namespace string,
+	volSyncDisabled bool,
 ) (*corev1.PersistentVolumeClaimList, error) {
 	// convert metav1.LabelSelector to a labels.Selector
 	pvcSelector, err := metav1.LabelSelectorAsSelector(&pvcLabelSelector)
@@ -84,6 +89,10 @@ func ListPVCsByPVCSelector(ctx context.Context, k8sClient client.Client, pvcLabe
 	return pvcList, nil
 }
 
+// IsPVCInUseByPod determines if there are any pod resources that reference the pvcName in the current
+// pvcNamespace and returns true if found. Further if inUsePodMustBeReady is true, returns true only if
+// the pod is in Ready state.
+// TODO: Should we trust the cached list here, or fetch it from the API server?
 func IsPVCInUseByPod(ctx context.Context,
 	k8sClient client.Client,
 	log logr.Logger,

--- a/controllers/util/pvcs_util_test.go
+++ b/controllers/util/pvcs_util_test.go
@@ -101,8 +101,8 @@ var _ = Describe("PVCS_Util", func() {
 			var pvcSelector metav1.LabelSelector
 
 			It("Should list all PVCs when VolSync is disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					true /* Volsync Disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), true /* Volsync Disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(pvcCount))
@@ -115,8 +115,8 @@ var _ = Describe("PVCS_Util", func() {
 			})
 
 			It("Should filter out VolSync PVCs when VolSync is not disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					false /* Volsync NOT disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), false /* Volsync NOT disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(pvcCount - 2)) // 2 PVCs are VolSync PVCs
@@ -135,8 +135,8 @@ var _ = Describe("PVCS_Util", func() {
 			}
 
 			It("Should list matching PVCs when VolSync is disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					true /* Volsync Disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), true /* Volsync Disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(3))
@@ -148,8 +148,8 @@ var _ = Describe("PVCS_Util", func() {
 			})
 
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					false /* Volsync NOT Disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), false /* Volsync NOT Disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))
@@ -168,8 +168,8 @@ var _ = Describe("PVCS_Util", func() {
 			}
 
 			It("Should list matching PVCs when VolSync is disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					true /* Volsync Disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), true /* Volsync Disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(2))
@@ -180,8 +180,8 @@ var _ = Describe("PVCS_Util", func() {
 			})
 
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					false /* Volsync NOT Disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), false /* Volsync NOT Disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))
@@ -207,8 +207,8 @@ var _ = Describe("PVCS_Util", func() {
 			// Overall this selector should AND matchLabels and MatchExpresssions, so should match pvcB & pvcC
 
 			It("Should list matching PVCs when VolSync is disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					true /* Volsync Disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), true /* Volsync Disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(2))
@@ -219,8 +219,8 @@ var _ = Describe("PVCS_Util", func() {
 			})
 
 			It("Should list matching PVCs and filter out VolSync PVCs when VolSync is not disabled", func() {
-				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, pvcSelector, testNamespace.GetName(),
-					false /* Volsync NOT Disabled */, testLogger)
+				pvcList, err := util.ListPVCsByPVCSelector(testCtx, k8sClient, testLogger, pvcSelector,
+					testNamespace.GetName(), false /* Volsync NOT Disabled */)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(pvcList).NotTo(BeNil())
 				Expect(len(pvcList.Items)).To(Equal(1))

--- a/controllers/volsync/volsync_suite_test.go
+++ b/controllers/volsync/volsync_suite_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/ramendr/ramen/controllers/volsync"
 
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	cfgpolicyv1 "github.com/stolostron/config-policy-controller/api/v1"
@@ -26,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	"github.com/ramendr/ramen/controllers/util"
 )
 
 var (
@@ -108,7 +108,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	// Index fields that are required for VSHandler
-	err = volsync.IndexFieldsForVSHandler(context.TODO(), k8sManager.GetFieldIndexer())
+	err = util.IndexFieldsForVSHandler(context.TODO(), k8sManager.GetFieldIndexer())
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -40,6 +40,7 @@ import (
 
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/controllers/util"
 )
 
 const (
@@ -98,41 +99,6 @@ func NewVSHandler(ctx context.Context, client client.Client, log logr.Logger, ow
 	}
 
 	return vsHandler
-}
-
-// VSHandler will either look at VolumeAttachments or pods to determine if a PVC is mounted
-// To do this, it requires an index on pods and volumeattachments to keep track of persistent volume claims mounted
-func IndexFieldsForVSHandler(ctx context.Context, fieldIndexer client.FieldIndexer) error {
-	// Index on pods - used to be able to check if a pvc is mounted to a pod
-	err := fieldIndexer.IndexField(ctx, &corev1.Pod{}, PodVolumePVCClaimIndexName, func(o client.Object) []string {
-		var res []string
-		for _, vol := range o.(*corev1.Pod).Spec.Volumes {
-			if vol.PersistentVolumeClaim == nil {
-				continue
-			}
-			// just return the raw field value -- the indexer will take care of dealing with namespaces for us
-			res = append(res, vol.PersistentVolumeClaim.ClaimName)
-		}
-
-		return res
-	})
-	if err != nil {
-		return fmt.Errorf("%w", err)
-	}
-
-	// Index on volumeattachments - used to be able to check if a pvc is mounted to a node
-	// This will be the preferred check to determine if a PVC is unmounted (i.e. if no volume attachment
-	// to any node, then the PV for a PVC is unmounted).  However not all storage drivers may support this.
-	return fieldIndexer.IndexField(ctx, &storagev1.VolumeAttachment{}, VolumeAttachmentToPVIndexName,
-		func(o client.Object) []string {
-			var res []string
-			sourcePVName := o.(*storagev1.VolumeAttachment).Spec.Source.PersistentVolumeName
-			if sourcePVName != nil {
-				res = append(res, *sourcePVName)
-			}
-
-			return res
-		})
 }
 
 // returns replication destination only if create/update is successful and the RD is considered available.
@@ -540,106 +506,14 @@ func (v *VSHandler) pvcExistsAndInUse(pvcName string, inUsePodMustBeReady bool) 
 
 	v.log.V(1).Info("pvc found", "pvcName", pvcName)
 
-	inUseByPod, err := v.isPvcInUseByPod(pvcName, inUsePodMustBeReady)
+	inUseByPod, err := util.IsPVCInUseByPod(v.ctx, v.client, v.log, pvcName, pvc.GetNamespace(), inUsePodMustBeReady)
 	if err != nil || inUseByPod || inUsePodMustBeReady {
 		// Return status immediately
 		return inUseByPod, err
 	}
 
 	// No pod is mounting the PVC - do additional check to make sure no volume attachment exists
-	return v.isPvAttachedToNode(pvc)
-}
-
-func (v *VSHandler) isPvcInUseByPod(pvcName string, inUsePodMustBeReady bool) (bool, error) {
-	podUsingPVCList := &corev1.PodList{}
-
-	err := v.client.List(context.Background(),
-		podUsingPVCList, // Our custom index - needs to be setup in the cache (see IndexFieldsForVSHandler())
-		client.MatchingFields{PodVolumePVCClaimIndexName: pvcName},
-		client.InNamespace(v.owner.GetNamespace()))
-	if err != nil {
-		v.log.Error(err, "unable to lookup pods to see if they are using pvc", "pvcName", pvcName)
-
-		return false, fmt.Errorf("unable to lookup pods to check if pvc is in use (%w)", err)
-	}
-
-	if len(podUsingPVCList.Items) == 0 {
-		return false /* Not in use by any pod */, nil
-	}
-
-	mountingPodIsReady := false
-
-	inUsePods := []string{}
-	for _, pod := range podUsingPVCList.Items {
-		inUsePods = append(inUsePods, fmt.Sprintf("pod: %s, phase: %s", pod.GetName(), pod.Status.Phase))
-
-		if pod.Status.Phase == corev1.PodRunning {
-			// Assuming in use by running pod if at least 1 pod mounting the PVC is in Running phase
-			// and has the Ready podCondition set to True
-			mountingPodIsReady = isPodReady(pod.Status.Conditions)
-		}
-	}
-
-	v.log.Info("pvc is in use by pod(s)", "pvcName", pvcName, "pods", inUsePods)
-
-	if inUsePodMustBeReady {
-		return mountingPodIsReady, nil
-	}
-
-	return true, nil
-}
-
-// For CSI drivers that support it, volume attachments will be created for the PV to indicate which node
-// they are attached to.  If a volume attachment exists, then we know the PV may not be ready to have a final
-// replication sync performed (I/Os may still not be completely written out).
-// This is a best-effort, as some CSI drivers may not support volume attachments (CSI driver Spec.AttachRequired: false)
-// in this case, we won't find a volumeattachment and will just assume the PV is not in use anymore.
-func (v *VSHandler) isPvAttachedToNode(pvc *corev1.PersistentVolumeClaim) (bool, error) {
-	pvName := pvc.Spec.VolumeName
-	if pvName == "" {
-		// Assuming if no volumename is set, the PVC has not been bound yet, so return false for in-use
-		v.log.V(1).Info("pvc has no VolumeName set, assuming not in-use", "pvcName", pvc.GetName())
-
-		return false, nil
-	}
-
-	// Lookup volumeattachments to determine if the PVC is mounted to a node - use our index
-	// (needs to be setup in the cache - see IndexFieldsForVSHandler())
-	volAttachmentList := &storagev1.VolumeAttachmentList{}
-
-	// Volume attachments are cluster-scoped, so no need to restrict query to our namespace
-	err := v.client.List(v.ctx,
-		volAttachmentList,
-		client.MatchingFields{VolumeAttachmentToPVIndexName: pvName})
-	if err != nil {
-		v.log.Error(err, "unable to lookup volumeattachments to see if pv for pvc is in use",
-			"pvcName", pvc.GetName(), "pvName", pvName)
-	}
-
-	if len(volAttachmentList.Items) == 0 {
-		// PV for our PVC is Not attached to any node
-		return false, nil
-	}
-
-	attachedNodes := []string{}
-	for _, volAttachment := range volAttachmentList.Items {
-		attachedNodes = append(attachedNodes, volAttachment.Spec.NodeName)
-	}
-
-	v.log.Info("pvc is attached to node(s), assuming in-use", "pvcName", pvc.GetName(), "pvName", pvName,
-		"nodes", attachedNodes)
-
-	return true, nil
-}
-
-func isPodReady(podConditions []corev1.PodCondition) bool {
-	for _, podCondition := range podConditions {
-		if podCondition.Type == corev1.PodReady && podCondition.Status == corev1.ConditionTrue {
-			return true
-		}
-	}
-
-	return false
+	return util.IsPVAttachedToNode(v.ctx, v.client, v.log, pvc)
 }
 
 func (v *VSHandler) deletePVC(pvcName string) error {

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -554,8 +554,8 @@ func (v *VRGInstance) restorePVs(result *ctrl.Result) error {
 }
 
 func (v *VRGInstance) listPVCsByPVCSelector() (*corev1.PersistentVolumeClaimList, error) {
-	return rmnutil.ListPVCsByPVCSelector(v.ctx, v.reconciler.Client, v.instance.Spec.PVCSelector, v.instance.Namespace,
-		v.instance.Spec.VolSync.Disabled, v.log)
+	return rmnutil.ListPVCsByPVCSelector(v.ctx, v.reconciler.Client, v.log, v.instance.Spec.PVCSelector,
+		v.instance.Namespace, v.instance.Spec.VolSync.Disabled)
 }
 
 // updatePVCList fetches and updates the PVC list to process for the current instance of VRG

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -174,7 +174,7 @@ func (v *VRGInstance) isPVCReadyForSecondary(pvc *corev1.PersistentVolumeClaim, 
 	if pvc.GetDeletionTimestamp().IsZero() {
 		log.Info("VolumeReplication cannot become Secondary, as its PersistentVolumeClaim is not marked for deletion")
 
-		msg := "PVC not being deleted. Not ready to become Secondary"
+		msg := "unable to transition to Secondary as PVC is not deleted"
 		v.updatePVCDataReadyCondition(pvc.Name, VRGConditionReasonProgressing, msg)
 
 		return !ready
@@ -186,7 +186,7 @@ func (v *VRGInstance) isPVCReadyForSecondary(pvc *corev1.PersistentVolumeClaim, 
 		log.Info("VolumeReplication cannot become Secondary, as its PersistentVolumeClaim is potentially"+
 			" in use by a pod", "errorValue", err)
 
-		msg := "PVC potentially in use by pod(s). Not ready to become Secondary"
+		msg := "unable to transition to Secondary as PVC is potentially in use by pod(s)"
 		v.updatePVCDataReadyCondition(pvc.Name, VRGConditionReasonProgressing, msg)
 
 		return !ready
@@ -198,7 +198,7 @@ func (v *VRGInstance) isPVCReadyForSecondary(pvc *corev1.PersistentVolumeClaim, 
 		log.Info("VolumeReplication cannot become Secondary, as its PersistentVolume is still"+
 			" attached to node(s)", "errorValue", err)
 
-		msg := "PersistentVolume for PVC still attached to node(s). Not ready to become Secondary"
+		msg := "unable to transition to Secondary as PersistentVolume for PVC is still attached to node(s)"
 		v.updatePVCDataReadyCondition(pvc.Name, VRGConditionReasonProgressing, msg)
 
 		return !ready

--- a/hack/pre-commit.sh
+++ b/hack/pre-commit.sh
@@ -38,10 +38,10 @@ function run_check() {
 # Install via: gem install mdl
 run_check '.*\.md' mdl --style "${scriptdir}/mdl-style.rb"
 
-# Install via: dnf install shellcheck
+# Install via: dnf install ShellCheck
 run_check '.*\.(ba)?sh' shellcheck
 
-# Install via: pip install yamllint
+# Install via: dnf install yamllint
 run_check '.*\.ya?ml' yamllint -s -c "${scriptdir}/yamlconfig.yaml"
 
 (! < "${OUTPUTS_FILE}" read -r)

--- a/main.go
+++ b/main.go
@@ -45,7 +45,6 @@ import (
 
 	"github.com/ramendr/ramen/controllers"
 	rmnutil "github.com/ramendr/ramen/controllers/util"
-	"github.com/ramendr/ramen/controllers/volsync"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -132,7 +131,7 @@ func setupReconcilers(mgr ctrl.Manager, ramenConfig *ramendrv1alpha1.RamenConfig
 	}
 
 	// Index fields that are required for VSHandler
-	if err := volsync.IndexFieldsForVSHandler(context.Background(), mgr.GetFieldIndexer()); err != nil {
+	if err := rmnutil.IndexFieldsForVSHandler(context.Background(), mgr.GetFieldIndexer()); err != nil {
 		setupLog.Error(err, "unable to index fields for controller", "controller", "VolumeReplicationGroup")
 		os.Exit(1)
 	}


### PR DESCRIPTION
    Current check to ensure PVC is not in use, specifically when
    VRG is moved to Secondary for relocation, relied on the PVC
    in use finalizer. This finalizer is removed earlier than the
    backing PV being unmounted/unmapped from a node. As a result
    in relocation cases this can cause data corruption as cached
    data maybe written post demoting the volume to Secondary.
    
    Instead of this the current code reuses the volsync method to,
    - Ensure there are no pods referencing the PVC
    - Ensure there are no pending VolumeAttachments for the PV
    
    The above is checked post PVC deletion, which results in no
    further possibility for the PVC to be actively used before
    demotion. Which hence avoids the potential corruption.