### PR TITLE
Bug 2130697: Rebuild DRPC state when DRPC is recovered from backup

### DIFF
--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -158,7 +158,7 @@ type DRPlacementControlStatus struct {
 	PreferredDecision  plrv1.PlacementDecision `json:"preferredDecision,omitempty"`
 	Conditions         []metav1.Condition      `json:"conditions,omitempty"`
 	ResourceConditions VRGConditions           `json:"resourceConditions,omitempty"`
-	LastUpdateTime     metav1.Time             `json:"lastUpdateTime"`
+	LastUpdateTime     *metav1.Time            `json:"lastUpdateTime,omitempty"`
 
 	// lastGroupSyncTime is the time of the most recent successful synchronization of all PVCs
 	//+optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -218,7 +218,10 @@ func (in *DRPlacementControlStatus) DeepCopyInto(out *DRPlacementControlStatus) 
 		}
 	}
 	in.ResourceConditions.DeepCopyInto(&out.ResourceConditions)
-	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
+	if in.LastUpdateTime != nil {
+		in, out := &in.LastUpdateTime, &out.LastUpdateTime
+		*out = (*in).DeepCopy()
+	}
 	if in.LastGroupSyncTime != nil {
 		in, out := &in.LastGroupSyncTime, &out.LastGroupSyncTime
 		*out = (*in).DeepCopy()

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -551,8 +551,6 @@ spec:
                     - namespace
                     type: object
                 type: object
-            required:
-            - lastUpdateTime
             type: object
         type: object
     served: true

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -472,7 +472,10 @@ func (r *DRPlacementControlReconciler) isBeingDeleted(drpc *rmn.DRPlacementContr
 
 func (r *DRPlacementControlReconciler) reconcileDRPCInstance(d *DRPCInstance, log logr.Logger) (ctrl.Result, error) {
 	// Last status update time BEFORE we start processing
-	beforeProcessing := d.instance.Status.LastUpdateTime
+	var beforeProcessing metav1.Time
+	if d.instance.Status.LastUpdateTime != nil {
+		beforeProcessing = *d.instance.Status.LastUpdateTime
+	}
 
 	requeue := d.startProcessing()
 	log.Info("Finished processing", "Requeue?", requeue)
@@ -496,7 +499,11 @@ func (r *DRPlacementControlReconciler) reconcileDRPCInstance(d *DRPCInstance, lo
 	}
 
 	// Last status update time AFTER processing
-	afterProcessing := d.instance.Status.LastUpdateTime
+	var afterProcessing metav1.Time
+	if d.instance.Status.LastUpdateTime != nil {
+		afterProcessing = *d.instance.Status.LastUpdateTime
+	}
+
 	requeueTimeDuration := r.getSanityCheckDelay(beforeProcessing, afterProcessing)
 	log.Info("Requeue time", "duration", requeueTimeDuration)
 
@@ -1009,7 +1016,9 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 		}
 	}
 
-	drpc.Status.LastUpdateTime = metav1.Now()
+	now := metav1.Now()
+	drpc.Status.LastUpdateTime = &now
+
 	for i, condition := range drpc.Status.Conditions {
 		if condition.ObservedGeneration != drpc.Generation {
 			drpc.Status.Conditions[i].ObservedGeneration = drpc.Generation

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -134,7 +134,9 @@ func (mwu *MWUtil) generateVRGManifestWork(name, namespace, homeCluster string,
 	return mwu.newManifestWork(
 		fmt.Sprintf(ManifestWorkNameFormat, name, namespace, MWTypeVRG),
 		homeCluster,
-		map[string]string{"app": "VRG"},
+		map[string]string{
+			"cluster.open-cluster-management.io/backup": "",
+		}, // backup this VRG MW as part of Hub Recovery
 		manifests, annotations), nil
 }
 


### PR DESCRIPTION
Two of the issues that we've seen with the hub recovery tests are:
1. VRG MW didn't get backed up
2. Velero not restoring the resources with their status.

For the first issue, the fix is easy; just add the backup label to the VRG MW. For the second one, the PlacementRule depends on the DRPC to update its status. That didn't work when the action has already been changed to 'Failover' or 'Relocate' prior or at the time of the resource backup.

This PR fixes the first issue by adding a backup label to the VRG MW. And it fixes the second issue by querying the Managed Clusters for VRGs and rebuilds the DRPC state with the query result.

If the DRPC state can't be rebuilt, for example, let's look at the following scenario:
1. The user failed over from C1 to C2
2. Hub backup is initiated
3. The user decides to relocate back to C1 from C2
4. Before another hub backup is taken, the hub crashes and the user needs to recover it somewhere else.

In that case, DRPC detects that the last action was a 'Failover' (from the drpc.spec.action), but it finds the primary VRG in the non failover cluster, which is contradicting. In that case, the user has to intervene and corrects the drpc.spec.action manually buy setting it to 'Relocate'.

Signed-off-by: Benamar Mekhissi <bmekhiss@redhat.com>
(cherry picked from commit ea569466d359489fea5c77953e09286de50d8220)