### PR TITLE
Bug 2138805: Fix relocate stalling when there are many PVCs for the same VRG

### DIFF
--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -163,7 +163,7 @@ func (d *DRPCInstance) containsMismatchVolSyncPVCs(srcVRG *rmn.VolumeReplication
 func (d *DRPCInstance) updateDestinationVRG(clusterName string, srcVRG *rmn.VolumeReplicationGroup,
 	dstVRG *rmn.VolumeReplicationGroup,
 ) error {
-	// clear RDInfo
+	// clear RDSpec
 	dstVRG.Spec.VolSync.RDSpec = nil
 
 	for _, protectedPVC := range srcVRG.Status.ProtectedPVCs {


### PR DESCRIPTION
This PR corrects two issues:
1. An accounting issue where during relocation, we run final sync for every protected PVC. When the final sync is complete, the VRG deletes the PVC. Deleting the PVC will cause the count to drop by 1 until all PVCs have finished running the final sync. The race condition is between completing the final sync and deleting the PVC. This case only happens when there are multiple PVCs to protect under one VRG.

2. When the VRG is successfully moved to secondary, the conditions might get stale as we  don't update all the condition for the secondary anymore. That can cause the cleanup to complete. The fix is to reset the status condition for the secondary.

Signed-off-by: Benamar Mekhissi <bmekhiss@redhat.com>
(cherry picked from commit 815efca14de9df82553f4e68c729baa4d1bc3a7e)