### PR TITLE
Bug 2118270: Allow multiple failovers when PVCs are not deleted

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1802,7 +1802,7 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	}
 
 	if v.pvMatches(existingPV, pv) {
-		v.log.Info("existing PV matches and is bound to the same claim", "PV", existingPV.GetName())
+		v.log.Info("Existing PV matches and is bound to the same claim", "PV", existingPV.GetName())
 
 		return nil
 	}
@@ -1821,7 +1821,7 @@ func (v *VRGInstance) validatePVExistence(pv *corev1.PersistentVolume) error {
 	return fmt.Errorf("found existing PV (%s) not restored by Ramen and not matching with backed up PV", existingPV.Name)
 }
 
-// PVMatches checks if the PVs fields match, and is bound to a PVC. Used to detect PVCs that were not
+// pvMatches checks if the PVs fields match, and is bound to a PVC. Used to detect PVCs that were not
 // deleted, and hence PVC and PV is retained and available for use
 //
 //nolint:cyclop


### PR DESCRIPTION
Currently when recovering a failed cluster, we
wait for the PVC to be deleted to prevent potential
future usage of the same, before moving the VR to
Secondary.

This commit ignores the PVC deletion state on failover
on the failed cluster which is moved to Secondary. This
is safe as on failover the PV contents are resynced
hence not waiting for the PVC to be deleted is acceptable.

The commit also does not fail PV restores for PVCs and PVs
that are bound and are the same as the PVs from the S3
store.

The entire change hence allows, multiple failovers when
PVCs are not deleted by the workload.

Relocate still would need the PVCs to be deleted to ensure
there is no potential use of the same.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>
(cherry picked from commit https://github.com/red-hat-storage/ramen/commit/7df3478bef7da47cb4b4ca92a65b43659cb451ec)