### PR TITLE
Bug 2143148: vrg: requeue if pvc is still in use

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -140,7 +140,7 @@ func (v *VRGInstance) reconcileVRAsSecondary(pvc *corev1.PersistentVolumeClaim, 
 	)
 
 	if !v.isPVCReadyForSecondary(pvc, log) {
-		return !requeue, false, skip
+		return requeue, false, skip
 	}
 
 	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}


### PR DESCRIPTION
If the PVC is in use by a pod, we prevent the transition of the VRG to secondary. In such cases, we should requeue so that the PVC in-use state is evaluated again.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>
(cherry picked from commit 7122139b4f7e67cbc944a909817b1f0c491afe6c)