### PR TITLE
Bug 2144180: Use CopyMethod Direct when setting up VolSync ReplicationDestination

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -131,6 +131,11 @@ type RamenConfig struct {
 		// the PVC's storageclass provisioner, a new storageclass will be created and the
 		// name of it passed to VolSync alongside the readOnly flag access mode.
 		CephFSCSIDriverName string `json:"cephFSCSIDriverName,omitempty"`
+
+		// destinationCopyMethod indicates the method that should be used when syncing
+		// from source to destination. Should be Snapshot/Direct
+		// default: Snapshot
+		DestinationCopyMethod string `json:"destinationCopyMethod,omitempty"`
 	} `json:"volSync,omitempty"`
 
 	KubeObjectProtection struct {

--- a/controllers/ramenconfig.go
+++ b/controllers/ramenconfig.go
@@ -40,6 +40,7 @@ const (
 	drClusterOperatorClusterServiceVersionNameDefault = drClusterOperatorPackageNameDefault + ".v0.0.1"
 	DefaultCephFSCSIDriverName                        = "openshift-storage.cephfs.csi.ceph.com"
 	VeleroNamespaceNameDefault                        = "velero"
+	DefaultVolSyncCopyMethod                          = "Snapshot"
 )
 
 // FIXME
@@ -288,4 +289,12 @@ func cephFSCSIDriverNameOrDefault(ramenConfig *ramendrv1alpha1.RamenConfig) stri
 	}
 
 	return ramenConfig.VolSync.CephFSCSIDriverName
+}
+
+func volSyncDestinationCopyMethodOrDefault(ramenConfig *ramendrv1alpha1.RamenConfig) string {
+	if ramenConfig.VolSync.DestinationCopyMethod == "" {
+		return DefaultVolSyncCopyMethod
+	}
+
+	return ramenConfig.VolSync.DestinationCopyMethod
 }

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -86,7 +86,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 			var vsHandler *volsync.VSHandler
 
 			BeforeEach(func() {
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none")
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot")
 			})
 
 			It("GetVolumeSnapshotClasses() should find all volume snapshot classes", func() {
@@ -115,7 +115,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none")
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot")
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -158,7 +158,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 					},
 				}
 
-				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none")
+				vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec, "none", "Snapshot")
 			})
 
 			It("GetVolumeSnapshotClasses() should find matching volume snapshot classes", func() {
@@ -215,7 +215,7 @@ var _ = Describe("VolSync Handler - Volume Replication Class tests", func() {
 
 			// Initialize a vshandler
 			vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, nil, asyncSpec,
-				"openshift-storage.cephfs.csi.ceph.com")
+				"openshift-storage.cephfs.csi.ceph.com", "Snapshot")
 		})
 
 		JustBeforeEach(func() {
@@ -430,7 +430,7 @@ var _ = Describe("VolSync Handler", func() {
 		Expect(ownerCm.GetName()).NotTo(BeEmpty())
 		owner = ownerCm
 
-		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none")
+		vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none", "Snapshot")
 	})
 
 	AfterEach(func() {
@@ -1447,7 +1447,8 @@ var _ = Describe("VolSync Handler", func() {
 			}
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
-			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec, "none")
+			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec,
+				"none", "Snapshot")
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRdSpec := ramendrv1alpha1.VolSyncReplicationDestinationSpec{
@@ -1636,7 +1637,8 @@ var _ = Describe("VolSync Handler", func() {
 			}
 			Expect(k8sClient.Create(ctx, otherOwnerCm)).To(Succeed())
 			Expect(otherOwnerCm.GetName()).NotTo(BeEmpty())
-			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec, "none")
+			otherVSHandler := volsync.NewVSHandler(ctx, k8sClient, logger, otherOwnerCm, asyncSpec,
+				"none", "Snapshot")
 
 			for i := 0; i < 2; i++ {
 				otherOwnerRsSpec := ramendrv1alpha1.VolSyncReplicationSourceSpec{

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -321,7 +321,8 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 
 	v.ramenConfig = ramenConfig
 	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance,
-		v.instance.Spec.Async, cephFSCSIDriverNameOrDefault(v.ramenConfig))
+		v.instance.Spec.Async, cephFSCSIDriverNameOrDefault(v.ramenConfig),
+		volSyncDestinationCopyMethodOrDefault(v.ramenConfig))
 
 	if v.instance.Status.ProtectedPVCs == nil {
 		v.instance.Status.ProtectedPVCs = []ramendrv1alpha1.ProtectedPVC{}

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -129,11 +129,10 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 		ProtectedPVC: *protectedPVC,
 	}
 
-	if v.instance.Spec.PrepareForFinalSync {
-		prepared, err := v.volSyncHandler.PreparePVCForFinalSync(pvc.Name)
-		if err != nil || !prepared {
-			return true
-		}
+	err := v.volSyncHandler.PreparePVC(pvc.Name, v.instance.Spec.PrepareForFinalSync,
+		v.volSyncHandler.IsCopyMethodDirect())
+	if err != nil {
+		return true
 	}
 
 	// reconcile RS and if runFinalSync is true, then one final sync will be run


### PR DESCRIPTION
    In this PR, added the option for VolSync to sync directly to the application PVC.
    This will resolve the issue where CephFS takes a long time to create an RWX PVC
    from a snapshot. Moreover, it resolves the issue where in some cases (PVC data size and latency)
    the first sync after failover/relocation takes a long time to fully copy the PVC to the
    destination side. Instead, with this change, only the delta is transferred.
    
    By default, the CopyMethod from source to destination will remain snapshot-based.
    If users want to use this new feature, they have to enable it through the Ramen configmap.
    ```
    volSync:
      destinationCopyMethod: "Direct"
    ```
    The caveat with this solution is that (affects only the failover), there is a probability of
    about 5% where the delta sync is in progress when we lose connectivity to the secondary cluster.
    If the user decides to failover at that point, then the data written to the destination PVC
    might be inconsistent as opposed to crash-consistent.