### PR TITLE
Bug 2144180: Sync directly to the App PVC and save crash-consistent snapshot at destination

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1629,7 +1629,7 @@ func (d *DRPCInstance) updateVRGState(clusterName string, state rmn.ReplicationS
 	}
 
 	if vrg.Spec.ReplicationState == state {
-		d.log.Info(fmt.Sprintf("VRG ReplicationState %s already %s on this cluster %s",
+		d.log.Info(fmt.Sprintf("VRG.Spec.ReplicationState %s already set to %s on this cluster %s",
 			vrg.Name, state, clusterName))
 
 		return false, nil

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -683,11 +683,11 @@ var _ = Describe("VolSync Handler", func() {
 					vsHandler = volsync.NewVSHandler(ctx, k8sClient, logger, owner, asyncSpec, "none", "Direct")
 				})
 
-				It("SelectDestCopyMethod() should return CopyMethod Direct and App PVC name", func() {
+				It("SelectDestCopyMethod() should return CopyMethod Snapshot and App PVC name", func() {
 					cpyMethod, dstPVC, err := vsHandler.SelectDestCopyMethod(rdSpec, logger)
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(cpyMethod).To(Equal(volsyncv1alpha1.CopyMethodDirect))
+					Expect(cpyMethod).To(Equal(volsyncv1alpha1.CopyMethodSnapshot))
 					Expect(*dstPVC).To(Equal(rdSpec.ProtectedPVC.Name))
 					pvc := &corev1.PersistentVolumeClaim{}
 					Eventually(func() error {
@@ -1265,7 +1265,7 @@ var _ = Describe("VolSync Handler", func() {
 						// Expect that the new pvc has been added as an owner
 						// on the VolumeSnapshot - it should NOT be a controller, as the replicationdestination
 						// will be the controller owning it
-						return ownerMatches(latestImageSnap, pvc.GetName(), "PersistentVolumeClaim", false /* not controller */)
+						return ownerMatches(latestImageSnap, owner.GetName(), "ConfigMap", false /* not controller */)
 					}, maxWait, interval).Should(BeTrue())
 				})
 

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -903,6 +903,13 @@ func (v *VRGInstance) updateVRGStatus(updateConditions bool) error {
 func (v *VRGInstance) updateStatusState() {
 	dataReadyCondition := findCondition(v.instance.Status.Conditions, VRGConditionTypeDataReady)
 	if dataReadyCondition == nil {
+		if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary &&
+			len(v.instance.Spec.VolSync.RDSpec) > 0 {
+			v.instance.Status.State = ramendrv1alpha1.SecondaryState
+
+			return
+		}
+
 		v.log.Info("Failed to find the DataReady condition in status")
 
 		return


### PR DESCRIPTION
Set up VolSync to save the last known good snapshot at the destination. This snapshot is replaced with a newer one every time a successful sync is complete. When the Application is failed over or relocated, this last snapshot will be retained for as long as the workload is deployed.

Additionally cherry picked fix for Bug 2108440