### PR TITLE
Increase max concurrent reconciles to 50 by default

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -93,7 +93,7 @@ type RamenConfig struct {
 
 	// MaxConcurrentReconciles is the maximum number of concurrent Reconciles which can be run.
 	// Defaults to 1.
-	MaxConcurrentReconciles int `json:",omitempty"`
+	MaxConcurrentReconciles int `json:"maxConcurrentReconciles,omitempty"`
 
 	// dr-cluster operator deployment/undeployment automation configuration
 	DrClusterOperator struct {

--- a/config/dr-cluster/manager/ramen_manager_config.yaml
+++ b/config/dr-cluster/manager/ramen_manager_config.yaml
@@ -10,3 +10,4 @@ leaderElection:
   leaderElect: true
   resourceName: dr-cluster.ramendr.openshift.io
 ramenControllerType: dr-cluster
+maxConcurrentReconciles: 50

--- a/config/hub/manager/ramen_manager_config.yaml
+++ b/config/hub/manager/ramen_manager_config.yaml
@@ -10,3 +10,4 @@ leaderElection:
   leaderElect: true
   resourceName: hub.ramendr.openshift.io
 ramenControllerType: dr-hub
+maxConcurrentReconciles: 50

--- a/examples/dr_cluster_config.yaml
+++ b/examples/dr_cluster_config.yaml
@@ -12,3 +12,4 @@ leaderElection:
   leaderElect: false
   resourceName: dr-cluster.ramendr.openshift.io
 ramenControllerType: "dr-cluster"
+maxConcurrentReconciles: 50

--- a/examples/dr_hub_config.yaml
+++ b/examples/dr_hub_config.yaml
@@ -12,3 +12,4 @@ leaderElection:
   leaderElect: false
   resourceName: hub.ramendr.openshift.io
 ramenControllerType: "dr-hub"
+maxConcurrentReconciles: 50


### PR DESCRIPTION
It was single threaded, and post testing this setting further, increasing it to 50.

This helps with reconciling multiple failovers or other actions in parallel across different resources, and improves the RTO objective.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>
(cherry picked from commit af502c13ecb2f8bcbb8e5c2ec9fd13367938ffa0)