### PR TITLE
fix config to enable sed replace for fusion bundle

### DIFF
--- a/config/hub/manifests/idr/ramen_manager_config_append.yaml
+++ b/config/hub/manifests/idr/ramen_manager_config_append.yaml
@@ -2,8 +2,8 @@ drClusterOperator:
   deploymentAutomationEnabled: true
   s3SecretDistributionEnabled: true
   channelName: alpha
-  packageName: odr-cluster-operator
+  packageName: ramen-dr-cluster-operator
   namespaceName: ramen-system
   catalogSourceName: ibm-catalogsource
   catalogSourceNamespaceName: openshift-marketplace
-  clusterServiceVersionName: odr-cluster-operator.v0.0.1
+  clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1


### PR DESCRIPTION
Ramen manager config added in #91 does not get sed replaced with information provided via variables. This is because it matches against upstream names for replacement. So, this change allows us to retain that behavior.