### PR TITLE
Bug 2173954: Ensure that PeerReady is set to true in the absence of any VRGs.

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -86,6 +86,11 @@ func (d *DRPCInstance) startProcessing() bool {
 func (d *DRPCInstance) processPlacement() (bool, error) {
 	d.log.Info("Process DRPC Placement", "DRAction", d.instance.Spec.Action)
 
+	if len(d.vrgs) == 0 {
+		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
+			metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
+	}
+
 	switch d.instance.Spec.Action {
 	case rmn.ActionFailover:
 		return d.RunFailover()


### PR DESCRIPTION
Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit 22ba25637ec4af300ade77510d06f4acb4110a05)