### PR TITLE
Bug 2172202: When there is at least one available cluster and no VRGs, set the con…

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -86,11 +86,6 @@ func (d *DRPCInstance) startProcessing() bool {
 func (d *DRPCInstance) processPlacement() (bool, error) {
 	d.log.Info("Process DRPC Placement", "DRAction", d.instance.Spec.Action)
 
-	if len(d.vrgs) == 0 {
-		d.setDRPCCondition(&d.instance.Status.Conditions, rmn.ConditionPeerReady, d.instance.Generation,
-			metav1.ConditionTrue, rmn.ReasonSuccess, "Ready")
-	}
-
 	switch d.instance.Spec.Action {
 	case rmn.ActionFailover:
 		return d.RunFailover()

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -346,7 +346,7 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	d, err := r.createDRPCInstance(ctx, drpc, usrPlRule, logger)
 	if err != nil && !errorswrapper.Is(err, InitialWaitTimeForDRPCPlacementRule) {
-		r.recordFailure(drpc, usrPlRule, "Error", err.Error(), logger)
+		err = r.updateDRPCStatus(drpc, usrPlRule, logger)
 
 		return ctrl.Result{}, err
 	}
@@ -860,29 +860,50 @@ func (r *DRPlacementControlReconciler) getVRGsFromManagedClusters(drpc *rmn.DRPl
 	annotations[DRPCNameAnnotation] = drpc.Name
 	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
 
+	var failedClusterToQuery string
+
+	var clustersQueriedSuccessfully int
+
 	for _, drCluster := range rmnutil.DrpolicyClusterNames(drPolicy) {
 		vrg, err := r.MCVGetter.GetVRGFromManagedCluster(drpc.Name, drpc.Namespace, drCluster, annotations)
 		if err != nil {
 			// Only NotFound error is accepted
 			if errors.IsNotFound(err) {
 				log.Info(fmt.Sprintf("VRG not found on %q", drCluster))
+				clustersQueriedSuccessfully++
 
 				continue
 			}
 
-			if drpc.Spec.Action == rmn.ActionFailover && drpc.Spec.FailoverCluster != drCluster {
-				log.Info(fmt.Sprintf("Skipping fetching VRG from %s due to failure. Error (%v)",
-					drCluster, err))
+			failedClusterToQuery = drCluster
 
-				continue
-			}
-
-			return vrgs, fmt.Errorf("failed to retrieve VRG from %s. err (%w)", drCluster, err)
+			log.Info(fmt.Sprintf("failed to retrieve VRG from %s. err (%v)", drCluster, err))
 		}
+
+		clustersQueriedSuccessfully++
 
 		vrgs[drCluster] = vrg
 
 		log.Info("VRG location", "VRG on", drCluster)
+	}
+
+	// We are done if we successfully queried all drClusters
+	if clustersQueriedSuccessfully == len(rmnutil.DrpolicyClusterNames(drPolicy)) {
+		return vrgs, nil
+	}
+
+	if clustersQueriedSuccessfully == 0 {
+		return vrgs, fmt.Errorf("failed to retrieve VRGs from clusters")
+	}
+
+	if len(vrgs) == 0 && failedClusterToQuery != drpc.Spec.FailoverCluster {
+		condition := findCondition(drpc.Status.Conditions, rmn.ConditionPeerReady)
+		if condition == nil {
+			SetDRPCStatusCondition(&drpc.Status.Conditions, rmn.ConditionPeerReady, drpc.Generation,
+				metav1.ConditionTrue, rmn.ReasonSuccess, "Forcing Ready")
+			SetDRPCStatusCondition(&drpc.Status.Conditions, rmn.ConditionAvailable,
+				drpc.Generation, metav1.ConditionTrue, rmn.ReasonSuccess, "Forcing Available")
+		}
 	}
 
 	return vrgs, nil


### PR DESCRIPTION
…ditions 'PeerReady' and 'Available' to true

Signed-off-by: Benamar Mekhissi <bmekhiss@redhat.com>
(cherry picked from commit a87076a6c6b51f11ab77979749fedd92fdcbe689)