### PR TITLE
add role, rolebinding and servicemonitor for metrics

### DIFF
--- a/config/hub/default/ocp/kustomization.yaml
+++ b/config/hub/default/ocp/kustomization.yaml
@@ -54,6 +54,8 @@ resources:
 - ../../rbac
 - ../../manager
 - ../../../webhook
+- ../../../prometheus
+- metrics_role_binding.yaml
 
 images:
 - name: kube-rbac-proxy

--- a/config/hub/default/ocp/metrics_role_binding.yaml
+++ b/config/hub/default/ocp/metrics_role_binding.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ramen-metrics
+  namespace: system
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ramen-metrics

--- a/config/hub/rbac/kustomization.yaml
+++ b/config/hub/rbac/kustomization.yaml
@@ -16,3 +16,4 @@ resources:
 - ../../rbac/auth_proxy_role.yaml
 - ../../rbac/auth_proxy_role_binding.yaml
 - ../../rbac/auth_proxy_client_clusterrole.yaml
+- ../../rbac/metrics_role.yaml

--- a/config/rbac/metrics_role.yaml
+++ b/config/rbac/metrics_role.yaml
@@ -1,0 +1,16 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ramen-metrics
+  namespace: system
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods


### PR DESCRIPTION
give permissions for prometheus-k8s
service account to scrape metrics.