### PR TITLE
Bug 2176179: Add missing continue keyword for failed MC query on VRG.

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -878,6 +878,8 @@ func (r *DRPlacementControlReconciler) getVRGsFromManagedClusters(drpc *rmn.DRPl
 			failedClusterToQuery = drCluster
 
 			log.Info(fmt.Sprintf("failed to retrieve VRG from %s. err (%v)", drCluster, err))
+
+			continue
 		}
 
 		clustersQueriedSuccessfully++


### PR DESCRIPTION
Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit bd414a5bd99d7219cdb3a3fc5bb8918aae23b564)