### PR TITLE
Bug 2188331: Filter and build ramen operator for different arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,3 +362,26 @@ catalog-build: opm ## Build a catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
+# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
+# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
+.PHONY: docker-buildx
+docker-buildx: # Build and push docker image for the manager for cross-platform support
+ifeq ($(DOCKERCMD),docker)
+	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} and 
+	# replace GOARCH value to ${TARGETARCH} into Dockerfile.cross, and preserve the original Dockerfile
+	$(eval PLATFORMS="linux/arm64,linux/amd64,linux/s390x,linux/ppc64le")
+	$(SED_CMD) \
+		-e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' \
+		-e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' \
+		Dockerfile > Dockerfile.cross
+	$(SED_CMD) -e 's/GOARCH=amd64/GOARCH=$${TARGETARCH}/' -i Dockerfile.cross
+	- $(DOCKERCMD) buildx create --name $(IMAGE_NAME)-builder --bootstrap --use 
+	- $(DOCKERCMD) buildx build --push --platform="${PLATFORMS}" --tag ${IMG} -f Dockerfile.cross .
+	- $(DOCKERCMD) buildx rm $(IMAGE_NAME)-builder
+	rm Dockerfile.cross
+else
+	@echo "docker-buildx is supported only with docker"
+endif

--- a/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
+++ b/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
@@ -7,6 +7,10 @@ metadata:
     operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: ramen-dr-cluster-operator.v0.0.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
+++ b/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
@@ -7,6 +7,10 @@ metadata:
     operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: ramen-hub-operator.v0.0.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported  
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:


### PR DESCRIPTION
This PR has two fixes

* Adding arch labels in CSV files helps OLM to filter the operator when the host OS is of a different arch. 
   Ref [BZ 2188331](https://bugzilla.redhat.com/show_bug.cgi?id=2188331)
* Build Ramen operator for different arch using `docker-buildx`