### PR TITLE
Bug 2211643: Backup application namespace manifestwork

### DIFF
--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -281,13 +281,19 @@ func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
 		return err
 	}
 
-	labels := map[string]string{}
 	manifests := []ocmworkv1.Manifest{
 		*manifest,
 	}
 
 	mwName := fmt.Sprintf(ManifestWorkNameFormat, name, namespaceName, MWTypeNS)
-	manifestWork := mwu.newManifestWork(mwName, managedClusterNamespace, labels, manifests, annotations)
+	manifestWork := mwu.newManifestWork(
+		mwName,
+		managedClusterNamespace,
+		map[string]string{
+			OCMBackupLabelKey: OCMBackupLabelValue,
+		},
+		manifests,
+		annotations)
 
 	return mwu.createOrUpdateManifestWork(manifestWork, managedClusterNamespace)
 }


### PR DESCRIPTION
In order to prevent workload eviction (see issue: https://issues.redhat.com/browse/ACM-5795) we now backup the application namespace ManifestWork resource used to create the namespace on the managed cluster.

Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit dbb1fe057731b32095a642ff8891297d559e8589)