### PR TITLE
Bug 2218181: Handle error when AppSets CRDs are missing

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1707,6 +1707,12 @@ func getApplicationDestinationNamespace(
 ) (string, error) {
 	appSetList := argov1alpha1.ApplicationSetList{}
 	if err := client.List(context.TODO(), &appSetList); err != nil {
+		// If ApplicationSet CRD is not found in the API server,
+		// default to Subscription behavior, and return the placement namespace as the target VRG namespace
+		if meta.IsNoMatchError(err) {
+			return placement.GetNamespace(), nil
+		}
+
 		return "", fmt.Errorf("ApplicationSet list: %w", err)
 	}
 


### PR DESCRIPTION
We see an error when trying to list AppSets when AppSet CRDs are not installed hence ramen was in an error state and unable to proceed as the VRG namespace was not returned. This is fixed by returning the default namespace when AppSets CRDs are not found.