### PR TITLE
Bug 2218487: Set ClusterDataReady false if PV exists, is bound, and claim's deletion timestamp is non-zero

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1936,28 +1936,44 @@ func (v *VRGInstance) updateExistingPVForSync(pv *corev1.PersistentVolume) error
 
 func (v *VRGInstance) validateExistingPV(pv *corev1.PersistentVolume) error {
 	existingPV := &corev1.PersistentVolume{}
+	log := v.log.WithValues("PV", existingPV.GetName())
 
 	err := v.reconciler.Get(v.ctx, types.NamespacedName{Name: pv.Name}, existingPV)
 	if err != nil {
 		return fmt.Errorf("failed to get PV (%s) (%w)", existingPV.GetName(), err)
 	}
 
-	// If the PV is bound and matches with the PV we would have restored then return now
-	if v.pvMatches(existingPV, pv) {
-		v.log.Info("Existing PV matches and is bound to the same claim", "PV", existingPV.GetName())
-
-		return nil
-	}
-
-	// If the PV is bound but does not match with the PV we would have restored then return error
 	if existingPV.Status.Phase == corev1.VolumeBound {
+		var pvc corev1.PersistentVolumeClaim
+
+		pvcNamespacedName := types.NamespacedName{Name: pv.Spec.ClaimRef.Name, Namespace: pv.Spec.ClaimRef.Namespace}
+
+		err := v.reconciler.Get(v.ctx, pvcNamespacedName, &pvc)
+		if err != nil {
+			return fmt.Errorf("failed to get PV %s claim %s: %w", existingPV.GetName(), pvcNamespacedName.String(), err)
+		}
+
+		if !pvc.DeletionTimestamp.IsZero() {
+			return fmt.Errorf("existing PV %s claim %s deletion timestamp non-zero %v", existingPV.GetName(),
+				pvcNamespacedName.String(), pvc.DeletionTimestamp)
+		}
+
+		// If the PV is bound and matches with the PV we would have restored then return now
+		if v.pvMatches(existingPV, pv) {
+			log.Info("Existing PV matches and is bound to the same claim")
+
+			return nil
+		}
+
 		return fmt.Errorf("existing PV (%s) is bound and doesn't match with the PV to be restored", existingPV.GetName())
 	}
+
+	log.Info("PV exists and is not bound", "phase", existingPV.Status.Phase)
 
 	// PV is not bound
 	// In sync case, we will update it to match with what we want to restore
 	if v.instance.Spec.Sync != nil {
-		v.log.Info("PV exists and will be updated for sync", "PV", existingPV.GetName())
+		log.Info("PV exists and will be updated for sync")
 
 		return v.updateExistingPVForSync(existingPV)
 	}
@@ -1968,7 +1984,7 @@ func (v *VRGInstance) validateExistingPV(pv *corev1.PersistentVolume) error {
 		existingPV.ObjectMeta.Annotations[RestoreAnnotation] == RestoredByRamen {
 		// Should we check and see if PV in being deleted? Should we just treat it as exists
 		// and then we don't care if deletion takes place later, which is what we do now?
-		v.log.Info("PV exists and managed by Ramen", "PV", existingPV.GetName())
+		log.Info("PV exists and managed by Ramen")
 
 		return nil
 	}
@@ -1997,7 +2013,7 @@ func (v *VRGInstance) validateExistingPVC(pvc *corev1.PersistentVolumeClaim) err
 	return nil
 }
 
-// pvMatches checks if the PVs fields match, and is bound to a PVC. Used to detect PVCs that were not
+// pvMatches checks if the PVs fields match presuming x is bound to a PVC. Used to detect PVCs that were not
 // deleted, and hence PVC and PV is retained and available for use
 //
 //nolint:cyclop
@@ -2005,10 +2021,6 @@ func (v *VRGInstance) pvMatches(x, y *corev1.PersistentVolume) bool {
 	switch {
 	case x.GetName() != y.GetName():
 		v.log.Info("PVs Name mismatch", "x", x.GetName(), "y", y.GetName())
-
-		return false
-	case x.Status.Phase != corev1.VolumeBound:
-		v.log.Info("PV not bound", "x", x.Status.Phase)
 
 		return false
 	case x.Spec.PersistentVolumeSource.CSI == nil || y.Spec.PersistentVolumeSource.CSI == nil:
@@ -2037,10 +2049,6 @@ func (v *VRGInstance) pvMatches(x, y *corev1.PersistentVolume) bool {
 		return false
 	case x.Spec.ClaimRef.Name != y.Spec.ClaimRef.Name:
 		v.log.Info("PVs ClaimRef.Name mismatch", "x", x.Spec.ClaimRef.Name, "y", y.Spec.ClaimRef.Name)
-
-		return false
-	case x.Spec.ClaimRef.UID != y.Spec.ClaimRef.UID:
-		v.log.Info("PVs ClaimRef.UID mismatch", "x", x.Spec.ClaimRef.UID, "y", y.Spec.ClaimRef.UID)
 
 		return false
 	case !reflect.DeepEqual(x.Spec.AccessModes, y.Spec.AccessModes):

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1935,12 +1935,11 @@ func (v *VRGInstance) updateExistingPVForSync(pv *corev1.PersistentVolume) error
 }
 
 func (v *VRGInstance) validateExistingPV(pv *corev1.PersistentVolume) error {
-	existingPV := &corev1.PersistentVolume{}
-	log := v.log.WithValues("PV", existingPV.GetName())
+	log := v.log.WithValues("PV", pv.Name)
 
-	err := v.reconciler.Get(v.ctx, types.NamespacedName{Name: pv.Name}, existingPV)
-	if err != nil {
-		return fmt.Errorf("failed to get PV (%s) (%w)", existingPV.GetName(), err)
+	existingPV := &corev1.PersistentVolume{}
+	if err := v.reconciler.Get(v.ctx, types.NamespacedName{Name: pv.Name}, existingPV); err != nil {
+		return fmt.Errorf("failed to get PV %s: %w", pv.Name, err)
 	}
 
 	if existingPV.Status.Phase == corev1.VolumeBound {

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1807,12 +1807,7 @@ func (v *VRGInstance) restorePVsFromObjectStore(objectStore ObjectStorer, s3Prof
 		return 0, fmt.Errorf("%s: %w", errMsg, err)
 	}
 
-	objList := make([]client.Object, 0, len(pvList))
-	for idx := range pvList {
-		objList = append(objList, &pvList[idx])
-	}
-
-	return v.restoreClusterDataObjects(objList, "PV")
+	return restoreClusterDataObjects(v, pvList, "PV", cleanupPVForRestore, v.validateExistingPV)
 }
 
 func (v *VRGInstance) restorePVCsFromObjectStore(objectStore ObjectStorer, s3ProfileName string) (int, error) {
@@ -1825,13 +1820,9 @@ func (v *VRGInstance) restorePVCsFromObjectStore(objectStore ObjectStorer, s3Pro
 
 	v.log.Info(fmt.Sprintf("Found %d PVCs in s3 store using profile %s", len(pvcList), s3ProfileName))
 
-	objList := make([]client.Object, 0, len(pvcList))
-	for idx := range pvcList {
-		objList = append(objList, &pvcList[idx])
-		v.volRepPVCs = append(v.volRepPVCs, pvcList[idx])
-	}
+	v.volRepPVCs = append(v.volRepPVCs, pvcList...)
 
-	return v.restoreClusterDataObjects(objList, "PVC")
+	return restoreClusterDataObjects(v, pvcList, "PVC", cleanupPVCForRestore, v.validateExistingPVC)
 }
 
 // checkPVClusterData returns an error if there are PVs in the input pvList
@@ -1874,16 +1865,31 @@ func (v *VRGInstance) checkPVClusterData(pvList []corev1.PersistentVolume) error
 	return nil
 }
 
-func (v *VRGInstance) restoreClusterDataObjects(objList []client.Object, objType string) (int, error) {
+func restoreClusterDataObjects[
+	ObjectType any,
+	ClientObject interface {
+		*ObjectType
+		client.Object
+	},
+](
+	v *VRGInstance,
+	objList []ObjectType, objType string,
+	cleanupForRestore func(*ObjectType),
+	validateExistingObject func(*ObjectType) error,
+) (int, error) {
 	numRestored := 0
 
-	for _, obj := range objList {
-		v.cleanupForRestore(obj)
-		v.addRestoreAnnotation(obj)
+	for i := range objList {
+		object := &objList[i]
+		objectCopy := &*object
+		obj := ClientObject(objectCopy)
+
+		cleanupForRestore(objectCopy)
+		addRestoreAnnotation(obj)
 
 		if err := v.reconciler.Create(v.ctx, obj); err != nil {
 			if k8serrors.IsAlreadyExists(err) {
-				err := v.validateExistingObject(obj)
+				err := validateExistingObject(objectCopy)
 				if err != nil {
 					v.log.Info("Object exists. Ignoring and moving to next object", "error", err.Error())
 					// ignoring any errors
@@ -1918,25 +1924,14 @@ func (v *VRGInstance) updateExistingPVForSync(pv *corev1.PersistentVolume) error
 	// failover/relocate process. Hence, the restore may not be
 	// required and the annotation for restore can be missing for
 	// the sync mode.
-	v.cleanupForRestore(pv)
-	v.addRestoreAnnotation(pv)
+	cleanupPVForRestore(pv)
+	addRestoreAnnotation(pv)
 
 	if err := v.reconciler.Update(v.ctx, pv); err != nil {
 		return fmt.Errorf("failed to cleanup existing PV for sync DR PV: %v, err: %w", pv.Name, err)
 	}
 
 	return nil
-}
-
-func (v *VRGInstance) validateExistingObject(obj client.Object) error {
-	switch p := obj.(type) {
-	case *corev1.PersistentVolume:
-		return v.validateExistingPV(p)
-	case *corev1.PersistentVolumeClaim:
-		return v.validateExistingPVC(p)
-	default:
-		return fmt.Errorf("unknown object %v", obj)
-	}
 }
 
 func (v *VRGInstance) validateExistingPV(pv *corev1.PersistentVolume) error {
@@ -2062,7 +2057,7 @@ func (v *VRGInstance) pvMatches(x, y *corev1.PersistentVolume) bool {
 }
 
 // addRestoreAnnotation adds annotation to an object indicating that the object was restored by Ramen
-func (v *VRGInstance) addRestoreAnnotation(obj client.Object) {
+func addRestoreAnnotation(obj client.Object) {
 	if obj.GetAnnotations() == nil {
 		obj.SetAnnotations(map[string]string{})
 	}
@@ -2072,21 +2067,20 @@ func (v *VRGInstance) addRestoreAnnotation(obj client.Object) {
 
 // cleanupForRestore cleans up required PV or PVC fields, to ensure restore succeeds
 // to a new cluster, and rebinding the PVC to an existing PV with the same claimRef
-func (v *VRGInstance) cleanupForRestore(obj client.Object) {
-	switch p := obj.(type) {
-	case *corev1.PersistentVolume:
-		p.ResourceVersion = ""
-		if p.Spec.ClaimRef != nil {
-			p.Spec.ClaimRef.UID = ""
-			p.Spec.ClaimRef.ResourceVersion = ""
-			p.Spec.ClaimRef.APIVersion = ""
-		}
-	case *corev1.PersistentVolumeClaim:
-		p.ObjectMeta.Annotations = PruneAnnotations(p.GetAnnotations())
-		p.ObjectMeta.Finalizers = []string{}
-		p.ObjectMeta.ResourceVersion = ""
-		p.ObjectMeta.OwnerReferences = nil
+func cleanupPVForRestore(pv *corev1.PersistentVolume) {
+	pv.ResourceVersion = ""
+	if pv.Spec.ClaimRef != nil {
+		pv.Spec.ClaimRef.UID = ""
+		pv.Spec.ClaimRef.ResourceVersion = ""
+		pv.Spec.ClaimRef.APIVersion = ""
 	}
+}
+
+func cleanupPVCForRestore(pvc *corev1.PersistentVolumeClaim) {
+	pvc.ObjectMeta.Annotations = PruneAnnotations(pvc.GetAnnotations())
+	pvc.ObjectMeta.Finalizers = []string{}
+	pvc.ObjectMeta.ResourceVersion = ""
+	pvc.ObjectMeta.OwnerReferences = nil
 }
 
 // Follow this logic to update VRG (and also ProtectedPVC) conditions for VolRep

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -2044,6 +2044,10 @@ func (v *VRGInstance) pvMatches(x, y *corev1.PersistentVolume) bool {
 		v.log.Info("PVs ClaimRef.Name mismatch", "x", x.Spec.ClaimRef.Name, "y", y.Spec.ClaimRef.Name)
 
 		return false
+	case x.Spec.ClaimRef.UID != y.Spec.ClaimRef.UID:
+		v.log.Info("PVs ClaimRef.UID mismatch", "x", x.Spec.ClaimRef.UID, "y", y.Spec.ClaimRef.UID)
+
+		return false
 	case !reflect.DeepEqual(x.Spec.AccessModes, y.Spec.AccessModes):
 		v.log.Info("PVs AccessMode mismatch", "x", x.Spec.AccessModes, "y", y.Spec.AccessModes)
 

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1947,14 +1947,13 @@ func (v *VRGInstance) validateExistingPV(pv *corev1.PersistentVolume) error {
 		var pvc corev1.PersistentVolumeClaim
 
 		pvcNamespacedName := types.NamespacedName{Name: pv.Spec.ClaimRef.Name, Namespace: pv.Spec.ClaimRef.Namespace}
-
-		err := v.reconciler.Get(v.ctx, pvcNamespacedName, &pvc)
-		if err != nil {
-			return fmt.Errorf("failed to get PV %s claim %s: %w", existingPV.GetName(), pvcNamespacedName.String(), err)
+		if err := v.reconciler.Get(v.ctx, pvcNamespacedName, &pvc); err != nil {
+			return fmt.Errorf("found bound PV %s to claim %s but unable to validate claim exists: %w", existingPV.GetName(),
+				pvcNamespacedName.String(), err)
 		}
 
 		if !pvc.DeletionTimestamp.IsZero() {
-			return fmt.Errorf("existing PV %s claim %s deletion timestamp non-zero %v", existingPV.GetName(),
+			return fmt.Errorf("existing bound PV %s claim %s deletion timestamp non-zero %v", existingPV.GetName(),
 				pvcNamespacedName.String(), pvc.DeletionTimestamp)
 		}
 

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -1889,7 +1889,7 @@ func restoreClusterDataObjects[
 
 		if err := v.reconciler.Create(v.ctx, obj); err != nil {
 			if k8serrors.IsAlreadyExists(err) {
-				err := validateExistingObject(objectCopy)
+				err := validateExistingObject(object)
 				if err != nil {
 					v.log.Info("Object exists. Ignoring and moving to next object", "error", err.Error())
 					// ignoring any errors


### PR DESCRIPTION
See https://github.com/RamenDR/ramen/pull/972