### PR TITLE
Bug 2229567: Disable vrgNamespace caching to prevent upgrade issues

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -295,7 +295,7 @@ func (d *DRPCInstance) startDeploying(homeCluster, homeClusterNamespace string) 
 
 	// All good, update the preferred decision and state
 	d.instance.Status.PreferredDecision.ClusterName = d.instance.Spec.PreferredCluster
-	d.instance.Status.PreferredDecision.ClusterNamespace = d.vrgNamespace
+	d.instance.Status.PreferredDecision.ClusterNamespace = d.instance.Spec.PreferredCluster
 
 	d.log.Info("Updated PreferredDecision", "PreferredDecision", d.instance.Status.PreferredDecision)
 
@@ -1356,7 +1356,7 @@ func (d *DRPCInstance) updatePreferredDecision() {
 		reflect.DeepEqual(d.instance.Status.PreferredDecision, plrv1.PlacementDecision{}) {
 		d.instance.Status.PreferredDecision = plrv1.PlacementDecision{
 			ClusterName:      d.instance.Spec.PreferredCluster,
-			ClusterNamespace: d.vrgNamespace,
+			ClusterNamespace: d.instance.Spec.PreferredCluster,
 		}
 	}
 }

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1009,7 +1009,7 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 		Ctx:             ctx,
 		Log:             r.Log,
 		InstName:        drpc.Name,
-		TargetNamespace: drpc.Status.PreferredDecision.ClusterNamespace,
+		TargetNamespace: vrgNamespace,
 	}
 
 	drPolicy, err := r.getDRPolicy(ctx, drpc, log)
@@ -1811,10 +1811,6 @@ func selectVRGNamespace(
 	drpc *rmn.DRPlacementControl,
 	placementObj client.Object,
 ) (string, error) {
-	if drpc.Status.PreferredDecision.ClusterNamespace != "" {
-		return drpc.Status.PreferredDecision.ClusterNamespace, nil
-	}
-
 	switch placementObj.(type) {
 	case *clrapiv1beta1.Placement:
 		vrgNamespace, err := getApplicationDestinationNamespace(client, log, placementObj)


### PR DESCRIPTION
Previously, we implemented a caching mechanism for vrgNamespace to optimize
the process of fetching the namespace of the application when it is part of
the ApplicationSet. However, this approach caused an upgrade problem when
moving from version 4.12 to 4.13. This commit will disable the vrgNamespace
caching until all customers have upgraded to version 4.13 or later.

Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit 572c9dc)