### PR TITLE
Bug 2232552: Find PlacementDecision by Placement label selector

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -51,7 +51,12 @@ const (
 	// This is needed in order to sync up the DRPC status and the VRG status.
 	StatusCheckDelay = time.Minute * 10
 
-	PlacementDecisionName = "%s-decision-1"
+	// PlacementDecisionName format, prefix is the Placement name, and suffix is a PlacementDecision index
+	PlacementDecisionName = "%s-decision-%d"
+
+	// Maximum retries to create PlacementDecisionName with an increasing index in case of conflicts
+	// with existing PlacementDecision resources
+	MaxPlacementDecisionConflictCount = 5
 )
 
 var InitialWaitTimeForDRPCPlacementRule = errorswrapper.New("Waiting for DRPC Placement to produces placement decision")
@@ -1716,6 +1721,8 @@ func (r *DRPlacementControlReconciler) createOrUpdatePlacementRuleDecision(ctx c
 	return nil
 }
 
+// createOrUpdatePlacementDecision updates the PlacementDecision status for the given Placement with the passed
+// in new decision. If an existing PlacementDecision is not found, ad new Placement decision is created.
 func (r *DRPlacementControlReconciler) createOrUpdatePlacementDecision(ctx context.Context,
 	placement *clrapiv1beta1.Placement, newCD *clrapiv1beta1.ClusterDecision,
 ) error {
@@ -1725,28 +1732,8 @@ func (r *DRPlacementControlReconciler) createOrUpdatePlacementDecision(ctx conte
 	}
 
 	if plDecision == nil {
-		plDecisionName := fmt.Sprintf(PlacementDecisionName, placement.GetName())
-		plDecision = &clrapiv1beta1.PlacementDecision{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      plDecisionName,
-				Namespace: placement.Namespace,
-			},
-		}
-
-		// Set the Placement object to be the owner.  When it is deleted, the PlacementDecision is deleted
-		if err := ctrl.SetControllerReference(placement, plDecision, r.Client.Scheme()); err != nil {
-			return fmt.Errorf("failed to set controller reference %w", err)
-		}
-
-		plDecision.ObjectMeta.Labels = map[string]string{
-			clrapiv1beta1.PlacementLabel: placement.GetName(),
-		}
-
-		owner := metav1.NewControllerRef(placement, clrapiv1beta1.GroupVersion.WithKind("Placement"))
-		plDecision.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*owner}
-
-		if err := r.Create(ctx, plDecision); err != nil {
-			return fmt.Errorf("failed to create PlacementDecision %w", err)
+		if plDecision, err = r.createPlacementDecision(ctx, placement); err != nil {
+			return err
 		}
 	}
 
@@ -1772,6 +1759,53 @@ func (r *DRPlacementControlReconciler) createOrUpdatePlacementDecision(ctx conte
 	r.Log.Info("Created/Updated PlacementDecision", "PlacementDecision", plDecision)
 
 	return nil
+}
+
+// createPlacementDecision creates a new PlacementDecision for the given Placement. The PlacementDecision is
+// named in a predetermined format, and is searchable using the Placement name label against the PlacementDecision.
+// On conflicts with existing PlacementDecisions, the function retries, with limits, with different names to generate
+// a new PlacementDecision.
+func (r *DRPlacementControlReconciler) createPlacementDecision(ctx context.Context,
+	placement *clrapiv1beta1.Placement,
+) (*clrapiv1beta1.PlacementDecision, error) {
+	index := 1
+
+	plDecision := &clrapiv1beta1.PlacementDecision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(PlacementDecisionName, placement.GetName(), index),
+			Namespace: placement.Namespace,
+		},
+	}
+
+	// Set the Placement object to be the owner.  When it is deleted, the PlacementDecision is deleted
+	err := ctrl.SetControllerReference(placement, plDecision, r.Client.Scheme())
+	if err != nil {
+		return nil, fmt.Errorf("failed to set controller reference %w", err)
+	}
+
+	plDecision.ObjectMeta.Labels = map[string]string{
+		clrapiv1beta1.PlacementLabel: placement.GetName(),
+	}
+
+	owner := metav1.NewControllerRef(placement, clrapiv1beta1.GroupVersion.WithKind("Placement"))
+	plDecision.ObjectMeta.OwnerReferences = []metav1.OwnerReference{*owner}
+
+	for index <= MaxPlacementDecisionConflictCount {
+		if err = r.Create(ctx, plDecision); err == nil {
+			return plDecision, nil
+		}
+
+		if !errors.IsAlreadyExists(err) {
+			return nil, err
+		}
+
+		index++
+
+		plDecision.ObjectMeta.Name = fmt.Sprintf(PlacementDecisionName, placement.GetName(), index)
+	}
+
+	return nil, fmt.Errorf("multiple PlacementDecision conflicts found, unable to create a new"+
+		" PlacementDecision for Placement %s", placement.GetNamespace()+"/"+placement.GetName())
 }
 
 func getApplicationDestinationNamespace(

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1610,32 +1610,67 @@ func (r *DRPlacementControlReconciler) getClusterDecisionFromPlacementRule(plRul
 	}
 }
 
+// getPlacementDecisionFromPlacement returns a PlacementDecision for the passed in Placement if found, and nil otherwise
+// - The PlacementDecision is determined by listing all PlacementDecisions in the Placement namespace filtered on the
+// Placement label as set by OCM
+// - Function also ensures there is only one decision for a Placement, as the needed by the Ramen orchestrators, and
+// if not returns an error
+func (r *DRPlacementControlReconciler) getPlacementDecisionFromPlacement(placement *clrapiv1beta1.Placement,
+) (*clrapiv1beta1.PlacementDecision, error) {
+	matchLabels := map[string]string{
+		clrapiv1beta1.PlacementLabel: placement.GetName(),
+	}
+
+	listOptions := []client.ListOption{
+		client.InNamespace(placement.GetNamespace()),
+		client.MatchingLabels(matchLabels),
+	}
+
+	plDecisions := &clrapiv1beta1.PlacementDecisionList{}
+	if err := r.List(context.TODO(), plDecisions, listOptions...); err != nil {
+		return nil, fmt.Errorf("failed to list PlacementDecisions (placement: %s)",
+			placement.GetNamespace()+"/"+placement.GetName())
+	}
+
+	if len(plDecisions.Items) == 0 {
+		return nil, nil
+	}
+
+	if len(plDecisions.Items) > 1 {
+		return nil, fmt.Errorf("multiple PlacementDecisions found for Placement (count: %d, placement: %s)",
+			len(plDecisions.Items), placement.GetNamespace()+"/"+placement.GetName())
+	}
+
+	plDecision := plDecisions.Items[0]
+	r.Log.Info("Found ClusterDecision", "ClsDedicision", plDecision.Status.Decisions)
+
+	if len(plDecision.Status.Decisions) > 1 {
+		return nil, fmt.Errorf("multiple placements found in PlacementDecision"+
+			" (count: %d, Placement: %s, PlacementDecision: %s)",
+			len(plDecision.Status.Decisions),
+			placement.GetNamespace()+"/"+placement.GetName(),
+			plDecision.GetName()+"/"+plDecision.GetNamespace())
+	}
+
+	return &plDecision, nil
+}
+
+// getClusterDecisionFromPlacement returns the cluster decision for a given Placement if found
 func (r *DRPlacementControlReconciler) getClusterDecisionFromPlacement(placement *clrapiv1beta1.Placement,
 ) *clrapiv1beta1.ClusterDecision {
-	plDecisionName := fmt.Sprintf(PlacementDecisionName, placement.GetName())
-	plDecision := &clrapiv1beta1.PlacementDecision{}
-
-	err := r.Get(context.TODO(), types.NamespacedName{Name: plDecisionName, Namespace: placement.Namespace}, plDecision)
+	plDecision, err := r.getPlacementDecisionFromPlacement(placement)
 	if err != nil {
-		if !errors.IsNotFound(err) {
-			r.Log.Info("Failed to retrieve PlacementDecision", "pdName", plDecisionName)
-		}
+		// TODO: err ignored by this caller
+		r.Log.Info("failed to get placement decision", "error", err)
 
 		return &clrapiv1beta1.ClusterDecision{}
 	}
 
-	r.Log.Info("Found ClusterDecision", "ClsDedicision", plDecision.Status.Decisions)
-
-	var clusterName, reason string
-	if len(plDecision.Status.Decisions) > 0 {
-		clusterName = plDecision.Status.Decisions[0].ClusterName
-		reason = plDecision.Status.Decisions[0].Reason
+	if plDecision == nil || len(plDecision.Status.Decisions) == 0 {
+		return &clrapiv1beta1.ClusterDecision{}
 	}
 
-	return &clrapiv1beta1.ClusterDecision{
-		ClusterName: clusterName,
-		Reason:      reason,
-	}
+	return &plDecision.Status.Decisions[0]
 }
 
 func (r *DRPlacementControlReconciler) updateUserPlacementStatusDecision(ctx context.Context,
@@ -1684,18 +1719,18 @@ func (r *DRPlacementControlReconciler) createOrUpdatePlacementRuleDecision(ctx c
 func (r *DRPlacementControlReconciler) createOrUpdatePlacementDecision(ctx context.Context,
 	placement *clrapiv1beta1.Placement, newCD *clrapiv1beta1.ClusterDecision,
 ) error {
-	plDecisionName := fmt.Sprintf(PlacementDecisionName, placement.GetName())
-	plDecision := &clrapiv1beta1.PlacementDecision{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      plDecisionName,
-			Namespace: placement.Namespace,
-		},
+	plDecision, err := r.getPlacementDecisionFromPlacement(placement)
+	if err != nil {
+		return err
 	}
 
-	key := client.ObjectKeyFromObject(plDecision)
-	if err := r.Get(ctx, key, plDecision); err != nil {
-		if !errors.IsNotFound(err) {
-			return err
+	if plDecision == nil {
+		plDecisionName := fmt.Sprintf(PlacementDecisionName, placement.GetName())
+		plDecision = &clrapiv1beta1.PlacementDecision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      plDecisionName,
+				Namespace: placement.Namespace,
+			},
 		}
 
 		// Set the Placement object to be the owner.  When it is deleted, the PlacementDecision is deleted

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1281,7 +1281,7 @@ func verifyUserPlacementRuleDecision(name, namespace, homeCluster string) {
 func getPlacementDecision(plName, plNamespace string) *clrapiv1beta1.PlacementDecision {
 	plDecision := &clrapiv1beta1.PlacementDecision{}
 	plDecisionKey := types.NamespacedName{
-		Name:      fmt.Sprintf(controllers.PlacementDecisionName, plName),
+		Name:      fmt.Sprintf(controllers.PlacementDecisionName, plName, 1),
 		Namespace: plNamespace,
 	}
 


### PR DESCRIPTION
PlacementDecisions created have a defined label carrying
the Placement for which it was created in the same
namespace as the Placement. This is a more deterministic
manner to find PlacementDecisions that are created for
a given Placement.

This commit removes the older scheme of depending on the
PlacementDecision naming scheme and moves to listing
PlacementDecisions by a label selector.