### PR TITLE
Bug 2235708: manifest name backport

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -68,7 +68,12 @@ func (d *DRPCInstance) startProcessing() bool {
 
 	if d.shouldUpdateStatus() || d.statusUpdateTimeElapsed() {
 		if err := d.reconciler.updateDRPCStatus(d.instance, d.userPlacement, d.metrics, d.log); err != nil {
-			d.log.Error(err, "failed to update status")
+			errMsg := fmt.Sprintf("error from update DRPC status: %v", err)
+			if processingErr != nil {
+				errMsg += fmt.Sprintf(", error from process placement: %v", processingErr)
+			}
+
+			d.log.Info(errMsg)
 
 			return requeue
 		}

--- a/controllers/drplacementcontrolvolsync.go
+++ b/controllers/drplacementcontrolvolsync.go
@@ -329,7 +329,7 @@ func (d *DRPCInstance) ResetVolSyncRDOnPrimary(clusterName string) error {
 		return nil
 	}
 
-	mw, err := d.mwu.FindManifestWork(rmnutil.MWTypeVRG, clusterName)
+	mw, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, clusterName)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil


### PR DESCRIPTION
Typo in function name - FindManifestWork instead of FindManifestWorkByType
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2235708