### PR TITLE
Disable dr fixes for 4.14

### DIFF
--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -803,13 +803,6 @@ func (v *VRGInstance) undoPVCFinalizersAndPVRetention(pvc *corev1.PersistentVolu
 
 	pvcNamespacedName := types.NamespacedName{Name: pvc.Name, Namespace: pvc.Namespace}
 
-	if pvc.GetAnnotations() != nil && pvc.GetAnnotations()[RestoreAnnotation] == RestoredByRamen {
-		// We created the PVC, delete it
-		if deleted := v.deletePVCIfNotInUse(pvc, log); !deleted {
-			return requeue
-		}
-	}
-
 	if err := v.deleteVR(pvcNamespacedName, log); err != nil {
 		log.Info("Requeuing due to failure in finalizing VolumeReplication resource for PersistentVolumeClaim",
 			"errorValue", err)

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -140,12 +140,7 @@ func (v *VRGInstance) reconcileVRAsSecondary(pvc *corev1.PersistentVolumeClaim, 
 		skip    bool = true
 	)
 
-	if pvc.GetAnnotations() != nil && pvc.GetAnnotations()[RestoreAnnotation] == RestoredByRamen {
-		// We created the PVC, delete it
-		if deleted := v.deletePVCIfNotInUse(pvc, log); !deleted {
-			return requeue, false, skip
-		}
-	} else if !v.isPVCReadyForSecondary(pvc, log) {
+	if !v.isPVCReadyForSecondary(pvc, log) {
 		return requeue, false, skip
 	}
 
@@ -175,14 +170,6 @@ func (v *VRGInstance) isPVCReadyForSecondary(pvc *corev1.PersistentVolumeClaim, 
 	}
 
 	return !v.isPVCInUse(pvc, log, "Secondary transition")
-}
-
-func (v *VRGInstance) deletePVCIfNotInUse(pvc *corev1.PersistentVolumeClaim, log logr.Logger) bool {
-	if v.isPVCInUse(pvc, log, "PVC deletion") {
-		return false
-	}
-
-	return rmnutil.DeletePVC(v.ctx, v.reconciler.Client, pvc.Name, pvc.Namespace, log) == nil
 }
 
 func (v *VRGInstance) isPVCInUse(pvc *corev1.PersistentVolumeClaim, log logr.Logger, operation string) bool {


### PR DESCRIPTION
- Fix disable DR for regional-dr and RBD storage
- Don't delete PVC when reconciling VRs as secondary

Both changes tested on top of release 4.13 and locally with minikube.

Upstream issues:
- https://github.com/RamenDR/ramen/issues/1022
- https://github.com/RamenDR/ramen/issues/833

(Not tracked in bugzilla)