### PR TITLE
Fix PVC deletion with CephFS (volsync)

### DIFF
--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -226,6 +226,10 @@ type ProtectedPVC struct {
 	//+optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
 
+	// Annotations for the PVC
+	//+optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
 	// Labels for the PVC
 	//+optional
 	Labels map[string]string `json:"labels,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -571,6 +571,13 @@ func (in *ProtectedPVC) DeepCopyInto(out *ProtectedPVC) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Labels != nil {
 		in, out := &in.Labels, &out.Labels
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
+++ b/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
@@ -340,6 +340,11 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: Annotations for the PVC
+                                        type: object
                                       conditions:
                                         description: Conditions for this protected
                                           pvc
@@ -753,6 +758,11 @@ spec:
                                 items:
                                   type: string
                                 type: array
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: Annotations for the PVC
+                                type: object
                               conditions:
                                 description: Conditions for this protected pvc
                                 items:

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -280,6 +280,11 @@ spec:
                               items:
                                 type: string
                               type: array
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations for the PVC
+                              type: object
                             conditions:
                               description: Conditions for this protected pvc
                               items:
@@ -659,6 +664,11 @@ spec:
                       items:
                         type: string
                       type: array
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations for the PVC
+                      type: object
                     conditions:
                       description: Conditions for this protected pvc
                       items:

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -83,3 +83,17 @@ func AddFinalizer(obj client.Object, finalizer string) bool {
 
 	return !finalizerAdded
 }
+
+// UpdateStringMap copies all key/value pairs in src adding them to map
+// referenced by the dst pointer. When a key in src is already present in dst,
+// the value in dst will be overwritten by the value associated with the key in
+// src.  The dst map is created if needed.
+func UpdateStringMap(dst *map[string]string, src map[string]string) {
+	if *dst == nil && len(src) > 0 {
+		*dst = make(map[string]string, len(src))
+	}
+
+	for key, val := range src {
+		(*dst)[key] = val
+	}
+}

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -1057,13 +1057,7 @@ func (v *VSHandler) ensurePVCFromSnapshot(rdSpec ramendrv1alpha1.VolSyncReplicat
 			return nil
 		}
 
-		if pvc.Labels == nil {
-			pvc.Labels = rdSpec.ProtectedPVC.Labels
-		} else {
-			for key, val := range rdSpec.ProtectedPVC.Labels {
-				pvc.Labels[key] = val
-			}
-		}
+		util.UpdateStringMap(&pvc.Labels, rdSpec.ProtectedPVC.Labels)
 
 		accessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce} // Default value
 		if len(rdSpec.ProtectedPVC.AccessModes) > 0 {

--- a/controllers/volsync/vshandler.go
+++ b/controllers/volsync/vshandler.go
@@ -1058,6 +1058,7 @@ func (v *VSHandler) ensurePVCFromSnapshot(rdSpec ramendrv1alpha1.VolSyncReplicat
 		}
 
 		util.UpdateStringMap(&pvc.Labels, rdSpec.ProtectedPVC.Labels)
+		util.UpdateStringMap(&pvc.Annotations, rdSpec.ProtectedPVC.Annotations)
 
 		accessModes := []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce} // Default value
 		if len(rdSpec.ProtectedPVC.AccessModes) > 0 {

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -1397,6 +1397,21 @@ var _ = Describe("VolSync_Handler", func() {
 					})
 				})
 
+				Context("When pvc to be restored has annotations", func() {
+					BeforeEach(func() {
+						rdSpec.ProtectedPVC.Annotations = map[string]string{
+							"include.me1": "value1",
+							"include.me2": "value2",
+						}
+					})
+
+					It("Should create PVC with annnotation", func() {
+						for k, v := range rdSpec.ProtectedPVC.Annotations {
+							Expect(pvc.Annotations).To(HaveKeyWithValue(k, v))
+						}
+					})
+				})
+
 				Context("When pvc to be restored has already been created", func() {
 					It("ensure PVC should not fail", func() {
 						// Previous ensurePVC will already have created the PVC (see parent context)

--- a/controllers/vrg_volsync_test.go
+++ b/controllers/vrg_volsync_test.go
@@ -112,6 +112,7 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 				pvcAnnotations := map[string]string{
 					"apps.open-cluster-management.io/hosting-subscription": "sub-name",
 					"apps.open-cluster-management.io/reconcile-option":     "merge",
+					volsync.ACMAppSubDoNotDeleteAnnotation:                 volsync.ACMAppSubDoNotDeleteAnnotationVal,
 					"pv.kubernetes.io/bind-completed":                      "yes",
 					"volume.kubernetes.io/storage-provisioner":             "provisioner",
 				}
@@ -164,6 +165,9 @@ var _ = Describe("VolumeReplicationGroupVolSyncController", func() {
 							"apps.open-cluster-management.io/hosting-subscription", "sub-name"))
 						Expect(vsPvc.Annotations).To(HaveKeyWithValue(
 							"apps.open-cluster-management.io/reconcile-option", "merge"))
+
+						// Except the do-no-delete annotion
+						Expect(vsPvc.Annotations).NotTo(HaveKey(volsync.ACMAppSubDoNotDeleteAnnotation))
 
 						// Other annotations are droopped.
 						Expect(vsPvc.Annotations).NotTo(HaveKey("pv.kubernetes.io/bind-completed"))


### PR DESCRIPTION
This change fix ownership of the application PVCs after relocate or failover.

In 4.13 this issue was solved by adding more permissions to ACM, and using the special
`mergeAndOwn` reconcile method. With this change using the default `merge` reconcile method
works without extra steps.

Tested on top of release 4.13.

Upstream issue:
- https://github.com/RamenDR/ramen/issues/1033

(not tracked in bugzilla)