### PR TITLE
Bug 2236387: Regenerate ACM Policy Name Resource When Length Exceeds 62 Characters

### DIFF
--- a/controllers/volsync/secret_propagator.go
+++ b/controllers/volsync/secret_propagator.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/ramendr/ramen/controllers/util"
 	plrulev1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
 	cfgpolicyv1 "open-cluster-management.io/config-policy-controller/api/v1"
 	policyv1 "open-cluster-management.io/governance-policy-propagator/api/v1"
@@ -75,11 +76,14 @@ type secretPropagator struct {
 	PlacementBindingName string
 }
 
+const policyNameMaxLength = 62
+
 func newSecretPropagator(ctx context.Context, k8sClient client.Client, sourceSecret *corev1.Secret,
 	ownerObject metav1.Object, destClusters []string, destSecretName, destSecretNamespace string,
 	log logr.Logger,
 ) secretPropagator {
-	secretPropagationPolicyName := ownerObject.GetName() + "-vs-secret"
+	secretPropagationPolicyName := util.GeneratePolicyName(ownerObject.GetName()+"-vs-secret",
+		policyNameMaxLength-len(ownerObject.GetNamespace()))
 	secretPropagationPolicyPlacementRuleName := secretPropagationPolicyName
 	secretPropagationPolicyPlacementBindingName := secretPropagationPolicyName
 


### PR DESCRIPTION
This pull request addresses an issue where the ACM policy name, combined with the namespace, exceeds the limit of 62 characters, as specified here. To comply with this limitation, we introduce logic to regenerate the policy name when necessary.

Changes Made:

We check whether the concatenation of the policy name and the namespace exceeds 62 characters.
If the total length is within the limit, the name remains unchanged.
If the total length exceeds 62 characters, we follow these steps:
Calculate an MD5 hash of the original name.
Prepend the hash with vs-secret- to create a new name.
Trim the new name to fit within the limit by removing characters from the end of the hash, up to (62 characters minus the length of the namespace). If the end result is less than 14 characters (length of vs-secret- plus 3 chars buffer), then we do nothing.
Examples:

Example 1:

Original Name: my-policy-name-vs-secret (24 characters)
Namespace: my-policy-namespace (19 characters)
Total Length: 43 characters (within the 62-character limit)
Result: The name remains unchanged.
Example 2:

Original Name: my-policy-name-pppppppppppppppppppp-vs-secret (45 characters)
Namespace: my-policy-namespace-pppppppppppppppppppp (40 characters)
Total Length: 85 characters (exceeds the 62-character limit)
Result:
MD5 Hash of Original Name: vs-secret-dd7542bf4c870b8b16777913b492e145
New Name: vs-secret-dd7542bf4c87 (22 characters)
Final Result: The name is trimmed to vs-secret-dd7542bf4c87
Example 3:

Original Name: my-policy-name--vs-secret (24 characters)
Namespace: my-policy-namespace-ppppppppppppppppppppaaaaaaaaaaaaaaaaaaaaaa (62 characters)
Total Length: 86 characters (exceeds the 62-character limit)
Result: Both the name and namespace are used as-is, as no changes are enforced, and we expect it to fail as it does today.
Fixes bz 2236387