### PR TITLE
Bug 2232242: Refactoring metrics creation and initialisation

### DIFF
--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -11,7 +11,7 @@ spec:
     - name: recording_rules
       rules:
         - record: ramen_sync_duration_seconds
-          expr: (time() - (ramen_last_sync_timestamp_seconds{job='ramen-hub-operator-metrics-service'} > 0))
+          expr: (time() - (ramen_last_sync_timestamp_seconds{job='ramen-hub-operator-metrics-service'}))
         - record: ramen_rpo_difference
           expr: ramen_sync_duration_seconds / on(policyname) group_left() (ramen_policy_schedule_interval_seconds{job="ramen-hub-operator-metrics-service"})
     - name: alerts

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -57,7 +57,6 @@ type DRPCInstance struct {
 	vrgs                 map[string]*rmn.VolumeReplicationGroup
 	vrgNamespace         string
 	mwu                  rmnutil.MWUtil
-	metrics              *DRPCMetrics
 }
 
 func (d *DRPCInstance) startProcessing() bool {
@@ -67,7 +66,7 @@ func (d *DRPCInstance) startProcessing() bool {
 	done, processingErr := d.processPlacement()
 
 	if d.shouldUpdateStatus() || d.statusUpdateTimeElapsed() {
-		if err := d.reconciler.updateDRPCStatus(d.instance, d.userPlacement, d.metrics, d.log); err != nil {
+		if err := d.reconciler.updateDRPCStatus(d.ctx, d.instance, d.userPlacement, d.log); err != nil {
 			errMsg := fmt.Sprintf("error from update DRPC status: %v", err)
 			if processingErr != nil {
 				errMsg += fmt.Sprintf(", error from process placement: %v", processingErr)


### PR DESCRIPTION
Metrics were previously created regardless of metro-dr or regional-dr. This has now changed, metrics are not created for metro-dr. The metrics instance creation is also moved from DRPC instance creation to updating DRPC condition, this is done so as not to initialize and set the default value as 0.

The values now refer to DRPC status and not VRG. we update DPRC LastGroup statuses based on the availability of VRG lastGroupSyncTime and the Relocate action. In case we do not get VRG, metrics will have the previous or the last known value from DRPC.

Removed 0 value filtering from alerts. So alerts are fired when metrics have zero value which is set based on DRPC lastGroupSynctime.

BZ: 2232242

