### PR TITLE
Bug 2153860: when policy is deleted fail placement reconcile with error

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -635,6 +635,8 @@ func (r *DRPlacementControlReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	drPolicy, err := r.getAndEnsureValidDRPolicy(ctx, drpc, logger)
 	if err != nil {
+		r.recordFailure(ctx, drpc, placementObj, "Error", err.Error(), logger)
+
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
It's an addition to PR https://github.com/red-hat-storage/ramen/pull/131. When policy is deleted, we need to inform user, trying to perform failover/relocate about the reason of failure.
 
Signed-off-by: Elena Gershkovich <elenage@il.ibm.com>
(cherry picked from commit 8eae033d5f53e66f8c13580fa3eca46d22461cc5)