### PR TITLE
Bug 2251205: Add label to volsync secret for inclusion in hub recovery backup

### DIFF
--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	OCMBackupLabelKey   string = "cluster.open-cluster-management.io/backup"
-	OCMBackupLabelValue string = "resource"
+	OCMBackupLabelValue string = "ramen"
 )
 
 func GenericAddLabelsAndFinalizers(

--- a/controllers/volsync/secretgen.go
+++ b/controllers/volsync/secretgen.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	rmnutil "github.com/ramendr/ramen/controllers/util"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,6 +76,9 @@ func generateNewVolSyncReplicationSecret(secretName, secretNamespace string, log
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      secretName,
 			Namespace: secretNamespace,
+			Labels: map[string]string{
+				rmnutil.OCMBackupLabelKey: rmnutil.OCMBackupLabelValue,
+			},
 		},
 		StringData: map[string]string{
 			"psk.txt": "volsyncramen:" + tlsKey,

--- a/controllers/volsync/secretgen_test.go
+++ b/controllers/volsync/secretgen_test.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	rmnutil "github.com/ramendr/ramen/controllers/util"
 	"github.com/ramendr/ramen/controllers/volsync"
 )
 
@@ -71,6 +72,9 @@ var _ = Describe("Secretgen", func() {
 
 				// Expect the secret should be owned by owner
 				Expect(ownerMatches(newSecret, owner.GetName(), "ConfigMap", true))
+
+				// Expect that the secret includes a label utilized for hub backup.
+				Expect(newSecret.GetLabels()[rmnutil.OCMBackupLabelKey]).Should(Equal(rmnutil.OCMBackupLabelValue))
 
 				// Check secret data
 				Expect(len(newSecret.Data)).To(Equal(1))


### PR DESCRIPTION
Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit 379daa1f957b4066a268b67e5ce2c6f7691756e5)