### PR TITLE
Bug 2215442: Disable vrgNamespace caching to prevent upgrade issues

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -282,7 +282,7 @@ func (d *DRPCInstance) startDeploying(homeCluster, homeClusterNamespace string) 
 
 	// All good, update the preferred decision and state
 	d.instance.Status.PreferredDecision.ClusterName = d.instance.Spec.PreferredCluster
-	d.instance.Status.PreferredDecision.ClusterNamespace = d.vrgNamespace
+	d.instance.Status.PreferredDecision.ClusterNamespace = d.instance.Spec.PreferredCluster
 
 	d.log.Info("Updated PreferredDecision", "PreferredDecision", d.instance.Status.PreferredDecision)
 
@@ -1324,7 +1324,7 @@ func (d *DRPCInstance) updatePreferredDecision() {
 		reflect.DeepEqual(d.instance.Status.PreferredDecision, plrv1.PlacementDecision{}) {
 		d.instance.Status.PreferredDecision = plrv1.PlacementDecision{
 			ClusterName:      d.instance.Spec.PreferredCluster,
-			ClusterNamespace: d.vrgNamespace,
+			ClusterNamespace: d.instance.Spec.PreferredCluster,
 		}
 	}
 }

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -30,6 +30,9 @@ const (
 	// Annotations for MW and PlacementRule
 	DRPCNameAnnotation      = "drplacementcontrol.ramendr.openshift.io/drpc-name"
 	DRPCNamespaceAnnotation = "drplacementcontrol.ramendr.openshift.io/drpc-namespace"
+
+	// Annotation for application namespace on the managed cluster
+	DRPCAppNamespace = "drplacementcontrol.ramendr.openshift.io/app-namespace"
 )
 
 var (

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -702,7 +702,7 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 		return nil, fmt.Errorf("failed to get DRPolicy %w", err)
 	}
 
-	if err := r.addLabelsAndFinalizers(ctx, drpc, placementObj, log); err != nil {
+	if err := r.updateObjectMetadata(ctx, drpc, placementObj, log); err != nil {
 		return nil, err
 	}
 
@@ -845,23 +845,32 @@ func (r *DRPlacementControlReconciler) getDRPolicy(ctx context.Context,
 	return drPolicy, nil
 }
 
-func (r DRPlacementControlReconciler) addLabelsAndFinalizers(ctx context.Context,
+// updateObjectMetadata updates drpc labels, annotations and finalizer, and also updates placementObj finalizer
+func (r DRPlacementControlReconciler) updateObjectMetadata(ctx context.Context,
 	drpc *rmn.DRPlacementControl, placementObj client.Object, log logr.Logger,
 ) error {
-	// add label and finalizer to DRPC
-	labelAdded := rmnutil.AddLabel(drpc, rmnutil.OCMBackupLabelKey, rmnutil.OCMBackupLabelValue)
-	finalizerAdded := rmnutil.AddFinalizer(drpc, DRPCFinalizer)
+	update := false
 
-	if labelAdded || finalizerAdded {
+	update = rmnutil.AddLabel(drpc, rmnutil.OCMBackupLabelKey, rmnutil.OCMBackupLabelValue)
+	update = rmnutil.AddFinalizer(drpc, DRPCFinalizer) || update
+
+	vrgNamespace, err := selectVRGNamespace(r.Client, r.Log, drpc, placementObj)
+	if err != nil {
+		return err
+	}
+
+	update = rmnutil.AddAnnotation(drpc, DRPCAppNamespace, vrgNamespace) || update
+
+	if update {
 		if err := r.Update(ctx, drpc); err != nil {
-			log.Error(err, "Failed to add label and finalizer to drpc")
+			log.Error(err, "Failed to add annotations, labels, or finalizer to drpc")
 
 			return fmt.Errorf("%w", err)
 		}
 	}
 
 	// add finalizer to User PlacementRule/Placement
-	finalizerAdded = rmnutil.AddFinalizer(placementObj, DRPCFinalizer)
+	finalizerAdded := rmnutil.AddFinalizer(placementObj, DRPCFinalizer)
 	if finalizerAdded {
 		if err := r.Update(ctx, placementObj); err != nil {
 			log.Error(err, "Failed to add finalizer to user placement rule")
@@ -1753,6 +1762,10 @@ func selectVRGNamespace(
 	drpc *rmn.DRPlacementControl,
 	placementObj client.Object,
 ) (string, error) {
+	if drpc.GetAnnotations() != nil && drpc.GetAnnotations()[DRPCAppNamespace] != "" {
+		return drpc.GetAnnotations()[DRPCAppNamespace], nil
+	}
+
 	switch placementObj.(type) {
 	case *clrapiv1beta1.Placement:
 		vrgNamespace, err := getApplicationDestinationNamespace(client, log, placementObj)

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -961,7 +961,7 @@ func (r *DRPlacementControlReconciler) finalizeDRPC(ctx context.Context, drpc *r
 		Ctx:             ctx,
 		Log:             r.Log,
 		InstName:        drpc.Name,
-		TargetNamespace: drpc.Status.PreferredDecision.ClusterNamespace,
+		TargetNamespace: vrgNamespace,
 	}
 
 	drPolicy, err := r.getDRPolicy(ctx, drpc, log)
@@ -1753,10 +1753,6 @@ func selectVRGNamespace(
 	drpc *rmn.DRPlacementControl,
 	placementObj client.Object,
 ) (string, error) {
-	if drpc.Status.PreferredDecision.ClusterNamespace != "" {
-		return drpc.Status.PreferredDecision.ClusterNamespace, nil
-	}
-
 	switch placementObj.(type) {
 	case *clrapiv1beta1.Placement:
 		vrgNamespace, err := getApplicationDestinationNamespace(client, log, placementObj)

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1767,6 +1767,7 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 	Expect(len(latestDRPC.Status.Conditions)).To(Equal(2))
 	_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
+	Expect(latestDRPC.GetAnnotations()[controllers.DRPCAppNamespace]).To(Equal(getVRGNameSpace()))
 }
 
 func verifyFailoverToSecondary(placementObj client.Object, toCluster string,

--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -72,6 +72,24 @@ func AddLabel(obj client.Object, key, value string) bool {
 	return !labelAdded
 }
 
+func AddAnnotation(obj client.Object, key, value string) bool {
+	const added = true
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	if keyValue, ok := annotations[key]; !ok || keyValue != value {
+		annotations[key] = value
+		obj.SetAnnotations(annotations)
+
+		return added
+	}
+
+	return !added
+}
+
 func AddFinalizer(obj client.Object, finalizer string) bool {
 	const finalizerAdded = true
 


### PR DESCRIPTION
Previously, we implemented a caching mechanism for vrgNamespace to optimize the process of fetching the namespace of the application when it is part of the ApplicationSet. However, this approach caused an upgrade problem when moving from version 4.12 to 4.13. This commit will disable the vrgNamespace caching until all customers have upgraded to version 4.13 or later.

Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit a94247ac2986e89ecbc769eabc76764a083ac4c8)