### PR TITLE
Bug 2260130: Disown volsync managed pvcs upon vrg deletion

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1524,6 +1524,7 @@ func (d *DRPCInstance) generateVRG(dstCluster string, repState rmn.ReplicationSt
 			Namespace: d.vrgNamespace,
 			Annotations: map[string]string{
 				DestinationClusterAnnotationKey: dstCluster,
+				DoNotDeletePVCAnnotation:        d.instance.GetAnnotations()[DoNotDeletePVCAnnotation],
 			},
 		},
 		Spec: rmn.VolumeReplicationGroupSpec{

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -59,6 +59,9 @@ const (
 	MaxPlacementDecisionConflictCount = 5
 
 	DestinationClusterAnnotationKey = "drplacementcontrol.ramendr.openshift.io/destination-cluster"
+
+	DoNotDeletePVCAnnotation    = "drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc"
+	DoNotDeletePVCAnnotationVal = "true"
 )
 
 var InitialWaitTimeForDRPCPlacementRule = errorswrapper.New("Waiting for DRPC Placement to produces placement decision")

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -1807,25 +1807,6 @@ var _ = Describe("VolSync_Handler", func() {
 				Expect(pvcPreparationErr).ToNot(HaveOccurred())
 				Expect(pvcPreparationComplete).To(BeTrue())
 
-				Eventually(func() int {
-					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(testPVC), testPVC)
-					if err != nil {
-						return 0
-					}
-
-					return len(testPVC.Annotations)
-				}, maxWait, interval).Should(Equal(len(initialAnnotations) - 2))
-				// We had 2 acm annotations in initialAnnotations
-
-				for key, val := range testPVC.Annotations {
-					if key != volsync.ACMAppSubDoNotDeleteAnnotation {
-						// Other ACM annotations should be deleted
-						Expect(strings.HasPrefix(key, "apps.open-cluster-management.io")).To(BeFalse())
-
-						Expect(initialAnnotations[key]).To(Equal(val)) // Other annotations should still be there
-					}
-				}
-
 				// ACM do-not-delete annotation should be added to the PVC
 				pvcAnnotations := testPVC.GetAnnotations()
 				val, ok := pvcAnnotations[volsync.ACMAppSubDoNotDeleteAnnotation]

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -774,6 +774,12 @@ func (v *VRGInstance) processForDeletion() ctrl.Result {
 
 	defer v.log.Info("Exiting processing VolumeReplicationGroup")
 
+	if err := v.disownPVCs(); err != nil {
+		v.log.Info("Disowning PVCs failed", "error", err)
+
+		return ctrl.Result{Requeue: true}
+	}
+
 	if !containsString(v.instance.ObjectMeta.Finalizers, vrgFinalizerName) {
 		v.log.Info("Finalizer missing from resource", "finalizer", vrgFinalizerName)
 

--- a/controllers/vrg_volsync.go
+++ b/controllers/vrg_volsync.go
@@ -402,3 +402,21 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 	// TODO Delete ReplicationSource, ReplicationDestination, etc.
 	v.pvcStatusDeleteIfPresent(pvc.Namespace, pvc.Name, log)
 }
+
+// disownPVCs this function is disassociating all PVCs (targeted for VolSync replication) from its owner (VRG)
+func (v *VRGInstance) disownPVCs() error {
+	if v.instance.GetAnnotations()[DoNotDeletePVCAnnotation] != DoNotDeletePVCAnnotationVal {
+		return nil
+	}
+
+	for idx := range v.volSyncPVCs {
+		pvc := &v.volSyncPVCs[idx]
+
+		err := v.volSyncHandler.DisownVolSyncManagedPVC(pvc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This commit introduces changes to disown PVC resources when a VRG is deleted, particularly in scenarios where the DR is disabled. The motivation behind this adjustment is to give back the management of the PVC lifecycle to OCM.

Upon disabling DR, the VRG now iterates through all volsync-managed PVCs. It removes VRG ownership from these PVCs and reinstates OCM annotations. This ensures that PVCs are not prematurely garbage collected upon VRG deletion.

In order for that to work, a new annotation needs to be added to the VRG to indicate that the PVCs should be disowned upon DR disabling drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: "true"

Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit d82d15511cca9adf2a2ae653cb6fdc00aaefd26a)