### PR TITLE
Bug 2240908: Check for metro policy using policy clusters

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -479,7 +479,7 @@ func DRPCsFailingOverToCluster(k8sclient client.Client, log logr.Logger, drclust
 		}
 
 		// Skip if policy is of type metro, fake the from and to cluster
-		if isMetroAction(&drpolicies.Items[drpolicyIdx], drClusters, drClusters[0].GetName(), drClusters[1].GetName()) {
+		if metro, _ := dRPolicySupportsMetro(&drpolicies.Items[drpolicyIdx], drClusters); metro {
 			log.Info("Sync DRPolicy detected, skipping!")
 
 			continue


### PR DESCRIPTION
Current check for metro actions that use isMetroAction passed in the to and from clusters to check equivalence of region values. This would succeed when to and from clusters are the same, which can happen when the preferredCluster and the failoverCluster are the same (Deploy->Failover->Failover).

As a result in a regional DR policy, such a state would enter processing or waiting for fencing to take effect before proceeding with the Failover.

This commit switches to the policy based metro determination instead of the to and from clusters as before to resolve the issue.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>
(cherry picked from commit b76fe12817e5d4d64ab2c41555b641be139ec65a)