### PR TITLE
Bug 2265147: Fix PV validation

### DIFF
--- a/controllers/util/misc.go
+++ b/controllers/util/misc.go
@@ -115,3 +115,8 @@ func UpdateStringMap(dst *map[string]string, src map[string]string) {
 		(*dst)[key] = val
 	}
 }
+
+// OptionalEqual returns True if optional field values are equal, or one of them is unset.
+func OptionalEqual(a, b string) bool {
+	return a == "" || b == "" || a == b
+}

--- a/controllers/vrg_volrep.go
+++ b/controllers/vrg_volrep.go
@@ -2162,7 +2162,7 @@ func (v *VRGInstance) pvMatches(x, y *corev1.PersistentVolume) bool {
 			"y", y.Spec.PersistentVolumeSource.CSI.FSType)
 
 		return false
-	case x.Spec.ClaimRef.Kind != y.Spec.ClaimRef.Kind:
+	case !rmnutil.OptionalEqual(x.Spec.ClaimRef.Kind, y.Spec.ClaimRef.Kind):
 		v.log.Info("PVs ClaimRef.Kind mismatch", "x", x.Spec.ClaimRef.Kind, "y", y.Spec.ClaimRef.Kind)
 
 		return false

--- a/docs/devel-quick-start.md
+++ b/docs/devel-quick-start.md
@@ -72,6 +72,22 @@ enough resources:
    link `venv` for activating the environment. To activate the
    environment use:
 
+1. Install Go 1.20
+
+   Ramen requires now Go 1.20 due to backward incompatible changes in Go
+   1.21 and later. If your system Go is newer and you don't want to
+   downgrade it, you can install Go 1.20 according to
+   [Managing Go installations](https://go.dev/doc/manage-install).
+
+   To use Go 1.20 from the ~/sdk, change the PATH in the shell used to
+   build ramen:
+
+   ```
+   $ export PATH="/home/username/sdk/go1.20.14/bin:$PATH"
+   $ go version
+   go version go1.20.14 linux/amd64
+   ```
+
 That's all! You are ready to submit your first pull request!
 
 ## Running the tests


### PR DESCRIPTION
When comparing PVs, skip comparing unset optional fields. This breaks validation when using
KubeVirt VM, and actual resources in the system do not match the backed up resources in
the s3 store, differing only in the optional "kind" field.

I could not reproduce the mismatch between s3 and actual resources, both
match after deploy and failover. So I would say this issue is not reproducible.

But after creating a mismatch manually by editing the PV claimRef, the issue
was reproduced, and replacing ramen image with the fix solved the issue.

Tested only on drenv environment.

Image for testing: quay.io/nirsof/ramen-operator:release-4.15-validate-pvc-v1