### PR TITLE
Bug 2154749: Add a Protected condition to DRPC that summarizes VRG conditions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,8 @@ linters-settings:
       SPDX-License-Identifier: Apache-2.0
   misspell:
     locale: US
+  promlinter:
+    strict: true
   wsl:
     allow-trailing-comment: true
     enforce-err-cuddling: true
@@ -149,6 +151,7 @@ linters:
     - nosprintfhostport
     - prealloc
     - predeclared
+    - promlinter
     - reassign
     - revive
     - rowserrcheck
@@ -192,6 +195,5 @@ linters:
     #  - containedctx
     #  - nonamedreturns
     #  - forcetypeassert
-    #  - promlinter
     #  - contextcheck
     #  - errname

--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -64,8 +64,17 @@ const (
 )
 
 const (
+	// Available condition provides the latest available observation regarding the readiness of the cluster,
+	// in status.preferredDecision, for workload deployment.
 	ConditionAvailable = "Available"
+
+	// PeerReady condition provides the latest available observation regarding the readiness of a peer cluster
+	// to failover or relocate the workload.
 	ConditionPeerReady = "PeerReady"
+
+	// Protected condition provides the latest available observation regarding the protection status of the workload,
+	// on the cluster it is expected to be available on.
+	ConditionProtected = "Protected"
 )
 
 const (
@@ -74,6 +83,13 @@ const (
 	ReasonSuccess     = "Success"
 	ReasonNotStarted  = "NotStarted"
 	ReasonPaused      = "Paused"
+)
+
+const (
+	ReasonProtectedUnknown     = "Unknown"
+	ReasonProtectedProgressing = "Progressing"
+	ReasonProtectedError       = "Error"
+	ReasonProtected            = "Protected"
 )
 
 type ProgressionStatus string

--- a/api/v1alpha1/drplacementcontrol_types.go
+++ b/api/v1alpha1/drplacementcontrol_types.go
@@ -192,6 +192,7 @@ type VRGConditions struct {
 // DRPlacementControlStatus defines the observed state of DRPlacementControl
 type DRPlacementControlStatus struct {
 	Phase              DRState                 `json:"phase,omitempty"`
+	ObservedGeneration int64                   `json:"observedGeneration,omitempty"`
 	ActionStartTime    *metav1.Time            `json:"actionStartTime,omitempty"`
 	ActionDuration     *metav1.Duration        `json:"actionDuration,omitempty"`
 	Progression        ProgressionStatus       `json:"progression,omitempty"`

--- a/api/v1alpha1/drpolicy_types.go
+++ b/api/v1alpha1/drpolicy_types.go
@@ -11,8 +11,6 @@ import (
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.replicationClassSelector) == has(self.replicationClassSelector)", message="replicationClassSelector is immutable"
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.volumeSnapshotClassSelector) == has(self.volumeSnapshotClassSelector)", message="volumeSnapshotClassSelector is immutable"
 type DRPolicySpec struct {
-	// Important: Run "make" to regenerate code after modifying this file
-
 	// scheduling Interval for replicating Persistent Volume
 	// data to a peer cluster. Interval is typically in the
 	// form <num><m,h,d>. Here <num> is a number, 'm' means
@@ -48,8 +46,6 @@ type DRPolicySpec struct {
 }
 
 // DRPolicyStatus defines the observed state of DRPolicy
-// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-// Important: Run "make" to regenerate code after modifying this file
 type DRPolicyStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -9,9 +9,6 @@ import (
 	cfg "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // ControllerType is the type of controller to run
 // +kubebuilder:validation:Enum=dr-hub;dr-cluster
 type ControllerType string

--- a/api/v1alpha1/volumereplicationgroup_types.go
+++ b/api/v1alpha1/volumereplicationgroup_types.go
@@ -10,8 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Important: Run "make" to regenerate code after modifying this file
-
 // ReplicationState represents the replication operations to be performed on the volume
 type ReplicationState string
 
@@ -137,8 +135,6 @@ type RecipeRef struct {
 }
 
 const KubeObjectProtectionCaptureIntervalDefault = 5 * time.Minute
-
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // VolumeReplicationGroup (VRG) spec declares the desired schedule for data
 // replication and replication state of all PVCs identified via the given
@@ -303,7 +299,6 @@ type KubeObjectProtectionStatus struct {
 }
 
 // VolumeReplicationGroupStatus defines the observed state of VolumeReplicationGroup
-// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 type VolumeReplicationGroupStatus struct {
 	State State `json:"state,omitempty"`
 

--- a/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drplacementcontrols.yaml
@@ -418,6 +418,9 @@ spec:
                   or the overall status was updated
                 format: date-time
                 type: string
+              observedGeneration:
+                format: int64
+                type: integer
               phase:
                 description: DRState for keeping track of the DR placement
                 type: string

--- a/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
+++ b/config/crd/bases/ramendr.openshift.io_drpolicies.yaml
@@ -173,10 +173,7 @@ spec:
             - message: volumeSnapshotClassSelector is immutable
               rule: has(oldSelf.volumeSnapshotClassSelector) == has(self.volumeSnapshotClassSelector)
           status:
-            description: |-
-              DRPolicyStatus defines the observed state of DRPolicy
-              INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-              Important: Run "make" to regenerate code after modifying this file
+            description: DRPolicyStatus defines the observed state of DRPolicy
             properties:
               conditions:
                 items:

--- a/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
+++ b/config/crd/bases/ramendr.openshift.io_protectedvolumereplicationgrouplists.yaml
@@ -626,9 +626,8 @@ spec:
                       - s3Profiles
                       type: object
                     status:
-                      description: |-
-                        VolumeReplicationGroupStatus defines the observed state of VolumeReplicationGroup
-                        INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                      description: VolumeReplicationGroupStatus defines the observed
+                        state of VolumeReplicationGroup
                       properties:
                         conditions:
                           description: Conditions are the list of VRG's summary conditions

--- a/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
+++ b/config/crd/bases/ramendr.openshift.io_volumereplicationgroups.yaml
@@ -566,9 +566,8 @@ spec:
             - s3Profiles
             type: object
           status:
-            description: |-
-              VolumeReplicationGroupStatus defines the observed state of VolumeReplicationGroup
-              INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+            description: VolumeReplicationGroupStatus defines the observed state of
+              VolumeReplicationGroup
             properties:
               conditions:
                 description: Conditions are the list of VRG's summary conditions and

--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -32,4 +32,12 @@ spec:
           annotations:
             description: "Syncing of volumes (DRPC: {{ $labels.obj_name }}, Namespace: {{ $labels.obj_namespace }}) is taking more than twice the scheduled snapshot interval. This may cause data loss and impact replication requests."
             alert_type: "DisasterRecovery"
+        - alert: WorkloadUnprotected
+          expr: ramen_workload_protection_status == 0
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            description: "Workload is not protected for disaster recovery (DRPC: {{ $labels.obj_name }}, Namespace: {{ $labels.obj_namespace }})."
+            alert_type: "DisasterRecovery"
     

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -1857,7 +1857,7 @@ func (d *DRPCInstance) ensureVRGIsSecondaryOnCluster(clusterName string) bool {
 		return false
 	}
 
-	if vrg.Status.State != rmn.SecondaryState {
+	if vrg.Status.State != rmn.SecondaryState || vrg.Status.ObservedGeneration != vrg.Generation {
 		d.log.Info(fmt.Sprintf("VRG on %s has not transitioned to secondary yet. Spec-State/Status-State %s/%s",
 			clusterName, vrg.Spec.ReplicationState, vrg.Status.State))
 

--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -2088,6 +2088,7 @@ func (d *DRPCInstance) setDRState(nextState rmn.DRState) {
 			d.instance.Status.Phase, nextState))
 
 		d.instance.Status.Phase = nextState
+		d.instance.Status.ObservedGeneration = d.instance.Generation
 		d.reportEvent(nextState)
 	}
 }

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1735,6 +1735,8 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 		}
 	}
 
+	// TODO: This is too generic, why are all conditions reported for the current generation?
+	// Each condition should choose for itself, no?
 	for i, condition := range drpc.Status.Conditions {
 		if condition.ObservedGeneration != drpc.Generation {
 			drpc.Status.Conditions[i].ObservedGeneration = drpc.Generation

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1722,22 +1722,13 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 ) error {
 	log.Info("Updating DRPC status")
 
-	vrgNamespace, err := selectVRGNamespace(r.Client, r.Log, drpc, userPlacement)
-	if err != nil {
-		log.Info("Failed to select VRG namespace", "error", err)
-	}
-
-	clusterDecision := r.getClusterDecision(userPlacement)
-	if clusterDecision != nil && clusterDecision.ClusterName != "" && vrgNamespace != "" {
-		// TODO: On relocate/failover cluster decision is nil, so older cluster decision is reported
-		r.updateResourceCondition(drpc, clusterDecision.ClusterName, vrgNamespace, log)
-	}
+	r.updateResourceCondition(drpc, userPlacement)
 
 	// do not set metrics if DRPC is being deleted
 	if !isBeingDeleted(drpc, userPlacement) {
 		if err := r.setDRPCMetrics(ctx, drpc, log); err != nil {
 			// log the error but do not return the error
-			log.Info("failed to set drpc metrics", "errMSg", err)
+			log.Info("Failed to set drpc metrics", "errMSg", err)
 		}
 	}
 
@@ -1768,14 +1759,26 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 }
 
 // updateResourceCondition updates DRPC status sub-resource with updated status from VRG if one exists,
-// - The VRG is read from the cluster where the workload is intended to be deployed
 // - The status update is NOT intended for a VRG that should be cleaned up on a peer cluster
 // It also updates DRPC ConditionProtected based on current state of VRG.
 func (r *DRPlacementControlReconciler) updateResourceCondition(
-	drpc *rmn.DRPlacementControl,
-	clusterName, vrgNamespace string,
-	log logr.Logger,
+	drpc *rmn.DRPlacementControl, userPlacement client.Object,
 ) {
+	vrgNamespace, err := selectVRGNamespace(r.Client, r.Log, drpc, userPlacement)
+	if err != nil {
+		r.Log.Info("Failed to select VRG namespace", "error", err)
+
+		return
+	}
+
+	clusterName := r.clusterForVRGStatus(drpc, userPlacement, r.Log)
+	if clusterName == "" {
+		r.Log.Info("Unable to determine managed cluster from which to inspect VRG, " +
+			"skipping processing ResourceConditions")
+
+		return
+	}
+
 	annotations := make(map[string]string)
 	annotations[DRPCNameAnnotation] = drpc.Name
 	annotations[DRPCNamespaceAnnotation] = drpc.Namespace
@@ -1783,7 +1786,7 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 	vrg, err := r.MCVGetter.GetVRGFromManagedCluster(drpc.Name, vrgNamespace,
 		clusterName, annotations)
 	if err != nil {
-		log.Info("Failed to get VRG from managed cluster", "errMsg", err.Error())
+		r.Log.Info("Failed to get VRG from managed cluster", "errMsg", err.Error())
 
 		drpc.Status.ResourceConditions = rmn.VRGConditions{}
 
@@ -1814,10 +1817,60 @@ func (r *DRPlacementControlReconciler) updateResourceCondition(
 	updateDRPCProtectedCondition(drpc, vrg, clusterName)
 }
 
+// clusterForVRGStatus determines which cluster's VRG should be inspected for status updates to DRPC
+func (r *DRPlacementControlReconciler) clusterForVRGStatus(
+	drpc *rmn.DRPlacementControl, userPlacement client.Object, log logr.Logger,
+) string {
+	clusterName := ""
+
+	clusterDecision := r.getClusterDecision(userPlacement)
+	if clusterDecision != nil && clusterDecision.ClusterName != "" {
+		clusterName = clusterDecision.ClusterName
+	}
+
+	switch drpc.Spec.Action {
+	case rmn.ActionFailover:
+		// Failover can rely on inspecting VRG from clusterDecision as it is never made nil, hence till
+		// placementDecision is changed to failoverCluster, we can inspect VRG from the existing cluster
+		return clusterName
+	case rmn.ActionRelocate:
+		if drpc.Status.ObservedGeneration != drpc.Generation {
+			log.Info("DPRC observedGeneration mismatches current generation, using ClusterDecision instead",
+				"Cluster", clusterName)
+
+			return clusterName
+		}
+
+		// We will inspect VRG from the non-preferredCluster until it reports Secondary, and then switch to the
+		// preferredCluster. This is done using Status.Progression for the DRPC
+		if IsPreRelocateProgression(drpc.Status.Progression) {
+			if value, ok := drpc.GetAnnotations()[LastAppDeploymentCluster]; ok && value != "" {
+				log.Info("Using cluster from LastAppDeploymentCluster annotation", "Cluster", value)
+
+				return value
+			}
+
+			log.Info("DPRC missing LastAppDeploymentCluster annotation, using ClusterDecision instead",
+				"Cluster", clusterName)
+
+			return clusterName
+		}
+
+		log.Info("Using DRPC preferredCluster, Relocate progression detected as switching to preferred cluster")
+
+		return drpc.Spec.PreferredCluster
+	}
+
+	// In cases of initial deployment use VRG from the preferredCluster
+	log.Info("Using DRPC preferredCluster, initial deploy detected")
+
+	return drpc.Spec.PreferredCluster
+}
+
 func (r *DRPlacementControlReconciler) setDRPCMetrics(ctx context.Context,
 	drpc *rmn.DRPlacementControl, log logr.Logger,
 ) error {
-	log.Info("setting drpc metrics")
+	log.Info("Setting drpc metrics")
 
 	drPolicy, err := r.getDRPolicy(ctx, drpc, log)
 	if err != nil {

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -2269,6 +2269,7 @@ func (r *DRPlacementControlReconciler) ensureDRPCStatusConsistency(
 		return !requeue, nil
 	case AllowFailover:
 		drpc.Status.Phase = rmn.WaitForUser
+		drpc.Status.ObservedGeneration = drpc.Generation
 		updateDRPCProgression(drpc, rmn.ProgressionActionPaused, log)
 		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionAvailable,
 			drpc.Generation, metav1.ConditionTrue, rmn.ReasonSuccess, msg)

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1565,7 +1565,7 @@ func runFailoverAction(placementObj client.Object, fromCluster, toCluster string
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
 	Expect(drpc.Status.Phase).To(Equal(rmn.FailedOver))
-	Expect(len(drpc.Status.Conditions)).To(Equal(2))
+	Expect(len(drpc.Status.Conditions)).To(Equal(3))
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
 	Expect(drpc.Status.ActionStartTime).ShouldNot(BeNil())
@@ -1618,7 +1618,7 @@ func runRelocateAction(placementObj client.Object, fromCluster string, isSyncDR 
 	// {Available and PeerReady}
 	// Final state is 'Relocated'
 	Expect(drpc.Status.Phase).To(Equal(rmn.Relocated))
-	Expect(len(drpc.Status.Conditions)).To(Equal(2))
+	Expect(len(drpc.Status.Conditions)).To(Equal(3))
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Relocated)))
 
@@ -1638,7 +1638,7 @@ func clearDRActionAfterRelocate(userPlacementRule *plrv1.PlacementRule, preferre
 	// Final state didn't change and it is 'Relocated' even though we tried to run
 	// initial deployment
 	Expect(drpc.Status.Phase).To(Equal(rmn.Deployed))
-	Expect(len(drpc.Status.Conditions)).To(Equal(2))
+	Expect(len(drpc.Status.Conditions)).To(Equal(3))
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
 
@@ -1763,7 +1763,7 @@ func verifyInitialDRPCDeployment(userPlacement client.Object, preferredCluster s
 	// {Available and PeerReady}
 	// Final state is 'Deployed'
 	Expect(latestDRPC.Status.Phase).To(Equal(rmn.Deployed))
-	Expect(len(latestDRPC.Status.Conditions)).To(Equal(2))
+	Expect(len(latestDRPC.Status.Conditions)).To(Equal(3))
 	_, condition := getDRPCCondition(&latestDRPC.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.Deployed)))
 	Expect(latestDRPC.GetAnnotations()[controllers.LastAppDeploymentCluster]).To(Equal(preferredCluster))
@@ -1797,7 +1797,7 @@ func verifyFailoverToSecondary(placementObj client.Object, toCluster string,
 	// {Available and PeerReady}
 	// Final state is 'FailedOver'
 	Expect(drpc.Status.Phase).To(Equal(rmn.FailedOver))
-	Expect(len(drpc.Status.Conditions)).To(Equal(2))
+	Expect(len(drpc.Status.Conditions)).To(Equal(3))
 	_, condition := getDRPCCondition(&drpc.Status, rmn.ConditionAvailable)
 	Expect(condition.Reason).To(Equal(string(rmn.FailedOver)))
 

--- a/controllers/protected_condition.go
+++ b/controllers/protected_condition.go
@@ -274,7 +274,7 @@ func updateMiscVRGStatus(drpc *rmn.DRPlacementControl,
 		return updated
 	}
 
-	if vrg.Status.LastGroupSyncTime.IsZero() {
+	if vrg.Spec.Async != nil && vrg.Status.LastGroupSyncTime.IsZero() {
 		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation, metav1.ConditionFalse,
 			rmn.ReasonProtectedProgressing, fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s "+
 				"is not reporting any lastGroupSyncTime as %s, retrying till status is met",

--- a/controllers/protected_condition.go
+++ b/controllers/protected_condition.go
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"fmt"
+
+	rmn "github.com/ramendr/ramen/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func updateProtectedConditionUnknown(drpc *rmn.DRPlacementControl, clusterName string) {
+	addOrUpdateCondition(
+		&drpc.Status.Conditions,
+		rmn.ConditionProtected,
+		drpc.Generation,
+		metav1.ConditionUnknown,
+		rmn.ReasonProtectedUnknown,
+		fmt.Sprintf("Missing VolumeReplicationGroup status from cluster %s", clusterName))
+}
+
+// updateDRPCProtectedCondition updates the DRPC status condition Protected based on various states of VRG, from the
+// cluster where the workload is expected to be placed. The VRG passed in should be the one where the workload is
+// currently deployed. e.g Primary, or in cases where we are waiting for VRG to report Secondary during Relocate
+func updateDRPCProtectedCondition(
+	drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) {
+	if updateVRGClusterDataReady(drpc, vrg, clusterName) {
+		return
+	}
+
+	switch vrg.Spec.ReplicationState {
+	case rmn.Primary:
+		if updateVRGDataReadyAsPrimary(drpc, vrg, clusterName) {
+			return
+		}
+
+		if updateVRGDataProtectedAsPrimary(drpc, vrg, clusterName) {
+			return
+		}
+	case rmn.Secondary:
+		if updateVRGDataReadyAsSecondary(drpc, vrg, clusterName) {
+			return
+		}
+
+		if updateVRGDataProtectedAsSecondary(drpc, vrg, clusterName) {
+			return
+		}
+	}
+
+	if updateMiscVRGStatus(drpc, vrg, clusterName) {
+		return
+	}
+
+	// ClusterDataProtected goes last, as this may always report true on Failover when one of the peer clusters is down
+	// and hence mask other failures above.
+	if updateVRGClusterDataProtected(drpc, vrg, clusterName) {
+		return
+	}
+
+	addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation,
+		metav1.ConditionTrue,
+		rmn.ReasonProtected,
+		fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s is protecting required resources and data",
+			vrg.GetNamespace(), vrg.GetName(), clusterName))
+}
+
+// updateVRGClusterDataReady is a helper function to process VRG ClusterDataReady condition and update DRPC
+// Protected condition.
+//   - Returns a bool that is true if status was updated, and false otherwise
+func updateVRGClusterDataReady(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	updated := true
+
+	// ClusterDataReady is only reported when VRG is Primary
+	if vrg.Spec.ReplicationState != rmn.Primary {
+		return !updated
+	}
+
+	return genericUpdateProtectedForCondition(drpc, vrg, clusterName, VRGConditionTypeClusterDataReady,
+		"workload resources readiness", "restoring workload resources", "restoring workload resources")
+}
+
+// updateVRGClusterDataProtected is a helper function to process VRG ClusterDataProtected condition and update DRPC
+// Protected condition.
+//   - Returns a bool that is true if status was updated, and false otherwise
+func updateVRGClusterDataProtected(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	updated := true
+
+	// ClusterDataProtected is only reported when VRG is Primary
+	if vrg.Spec.ReplicationState != rmn.Primary {
+		return !updated
+	}
+
+	return genericUpdateProtectedForCondition(drpc, vrg, clusterName, VRGConditionTypeClusterDataProtected,
+		"workload resource protection", "protecting workload resources", "protecting workload resources")
+}
+
+// updateVRGDataReadyAsPrimary is a helper function to process VRG DataReady when VRG is Primary and update DRPC
+// Protected condition
+//   - Returns a bool that is true if status was updated, and false otherwise
+func updateVRGDataReadyAsPrimary(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	return genericUpdateProtectedForCondition(drpc, vrg, clusterName, VRGConditionTypeDataReady,
+		"workload data readiness", "readying workload data", "readying workload data")
+}
+
+// updateVRGDataReadyAsSecondary is a helper function to process VRG DataReady when VRG is Secondary and update DRPC
+// Protected condition
+//   - Returns a bool that is true if status was updated, and false otherwise
+func updateVRGDataReadyAsSecondary(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	updated := true
+
+	condition := meta.FindStatusCondition(vrg.Status.Conditions, VRGConditionTypeDataReady)
+
+	// Volsync does not report in a DataReady condition as Secondary
+	if condition == nil {
+		return !updated
+	}
+
+	// NOTE: the check for reason Replicating is only a safety, a Secondary VRG with Failover action would not be
+	// used to provide Protected status (a Secondary VRG with Relocate may though, but in that case we want
+	// this to be true)
+	if condition.ObservedGeneration == vrg.Generation && condition.Status == metav1.ConditionFalse &&
+		condition.Reason == VRGConditionReasonReplicating && vrg.Spec.Async != nil &&
+		vrg.Spec.Action == rmn.VRGActionFailover {
+		return !updated
+	}
+
+	return genericUpdateProtectedForCondition(drpc, vrg, clusterName, VRGConditionTypeDataReady,
+		"workload data readiness", "readying workload data", "readying workload data")
+}
+
+// updateVRGDataProtectedAsPrimary is a helper function to process VRG DataProtected when VRG is Primary and update DRPC
+// Protected condition
+//   - Returns a bool that is true if status was updated, and false otherwise
+func updateVRGDataProtectedAsPrimary(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	updated := true
+
+	condition := meta.FindStatusCondition(vrg.Status.Conditions, VRGConditionTypeDataProtected)
+
+	if condition != nil && condition.ObservedGeneration == vrg.Generation {
+		// VRGConditionReasonReplicating reason is unique to VR based volumes
+		if condition.Reason == VRGConditionReasonReplicating && condition.Status == metav1.ConditionFalse &&
+			vrg.Spec.Async != nil {
+			return !updated
+		}
+
+		if condition.Status == metav1.ConditionTrue {
+			return !updated
+		}
+	}
+
+	return genericUpdateProtectedForCondition(drpc, vrg, clusterName, VRGConditionTypeDataProtected,
+		"workload data protection", "protecting workload data", "protecting workload data")
+}
+
+// updateVRGDataProtectedAsSecondary is a helper function to process VRG DataProtected when VRG is Secondary and update
+// DRPC Protected condition
+//   - Returns a bool that is true if status was updated, and false otherwise
+func updateVRGDataProtectedAsSecondary(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	updated := true
+
+	condition := meta.FindStatusCondition(vrg.Status.Conditions, VRGConditionTypeDataProtected)
+
+	// Volsync does not report in a DataReady condition as Secondary
+	if condition == nil {
+		return !updated
+	}
+
+	return genericUpdateProtectedForCondition(drpc, vrg, clusterName, VRGConditionTypeDataProtected,
+		"workload data protection", "protecting workload data", "protecting workload data")
+}
+
+// genericUpdateProtectedForCondition is a common helper that processes passed in VRG condition with varying VRG reasons
+// to determine DRPC Protected condition updates,
+func genericUpdateProtectedForCondition(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+	conditionName string,
+	msgUnknown, msgProgressing, msgError string,
+) bool {
+	updated := true
+
+	condition := meta.FindStatusCondition(vrg.Status.Conditions, conditionName)
+
+	if condition != nil && condition.Status == metav1.ConditionTrue && condition.ObservedGeneration == vrg.Generation {
+		return !updated
+	}
+
+	if condition == nil ||
+		condition.ObservedGeneration != vrg.Generation ||
+		condition.Status == metav1.ConditionUnknown {
+		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation,
+			metav1.ConditionUnknown,
+			rmn.ReasonProtectedUnknown,
+			fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s "+
+				"is not reporting any status about %s, "+
+				"retrying till %s condition is met",
+				vrg.GetNamespace(), vrg.GetName(),
+				clusterName, msgUnknown, conditionName))
+
+		return updated
+	}
+
+	// condition.Status == metav1.ConditionFalse for current generation, other states are exhausted above
+	if isVRGReasonError(condition) {
+		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation,
+			metav1.ConditionFalse,
+			rmn.ReasonProtectedError,
+			fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s is reporting errors (%s) %s, "+
+				"retrying till %s condition is met",
+				vrg.GetNamespace(), vrg.GetName(),
+				clusterName, condition.Message, msgError, conditionName))
+
+		return updated
+	}
+
+	addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation,
+		metav1.ConditionFalse,
+		rmn.ReasonProtectedProgressing,
+		fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s is progressing on %s (%s), "+
+			"retrying till %s condition is met",
+			vrg.GetNamespace(), vrg.GetName(),
+			clusterName, msgProgressing, condition.Message, conditionName))
+
+	return updated
+}
+
+// updateMiscVRGStatus processes VRG status fields other than conditions to determine DRPC Protected condition updates
+func updateMiscVRGStatus(drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	clusterName string,
+) bool {
+	updated := true
+
+	if vrg.Status.ObservedGeneration != vrg.Generation {
+		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation, metav1.ConditionFalse,
+			rmn.ReasonProtectedUnknown, fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s "+
+				"is not reporting status for current generation as %s, retrying till status is met",
+				vrg.GetNamespace(), vrg.GetName(),
+				clusterName, vrg.Spec.ReplicationState))
+
+		return updated
+	}
+
+	if vrg.Status.State != getStatusStateFromSpecState(vrg.Spec.ReplicationState) {
+		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation, metav1.ConditionFalse,
+			rmn.ReasonProtectedProgressing, fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s "+
+				"is not reporting status as %s, retrying till status is met",
+				vrg.GetNamespace(), vrg.GetName(),
+				clusterName, vrg.Spec.ReplicationState))
+
+		return updated
+	}
+
+	if vrg.Status.LastGroupSyncTime.IsZero() {
+		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation, metav1.ConditionFalse,
+			rmn.ReasonProtectedProgressing, fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s "+
+				"is not reporting any lastGroupSyncTime as %s, retrying till status is met",
+				vrg.GetNamespace(), vrg.GetName(),
+				clusterName, vrg.Spec.ReplicationState))
+
+		return updated
+	}
+
+	return !updated
+}

--- a/controllers/protectedvolumereplicationgrouplist_controller_test.go
+++ b/controllers/protectedvolumereplicationgrouplist_controller_test.go
@@ -128,6 +128,12 @@ func vrgStatusStateUpdate(vrgS3, vrgK8s *ramen.VolumeReplicationGroup) {
 		vrgS3.ResourceVersion = vrgK8s.ResourceVersion
 		vrgS3.Status.LastUpdateTime = vrgK8s.Status.LastUpdateTime
 	}
+
+	if vrgS3.Status.State == "" && vrgK8s.Status.State == ramen.UnknownState {
+		vrgS3.Status.State = ramen.UnknownState
+		vrgS3.ResourceVersion = vrgK8s.ResourceVersion
+		vrgS3.Status.LastUpdateTime = vrgK8s.Status.LastUpdateTime
+	}
 }
 
 var _ = Describe("ProtectedVolumeReplicationGroupListController", func() {

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -50,6 +50,7 @@ const (
 
 // VRG condition reasons
 const (
+	VRGConditionReasonUnused                      = "Unused"
 	VRGConditionReasonInitializing                = "Initializing"
 	VRGConditionReasonReplicating                 = "Replicating"
 	VRGConditionReasonReplicated                  = "Replicated"
@@ -117,13 +118,14 @@ func setVRGInitialCondition(conditions *[]metav1.Condition, observedGeneration i
 
 // sets conditions when VRG as Secondary is replicating the data with Primary.
 func setVRGDataReplicatingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, *newVRGDataReplicatingCondition(observedGeneration, message))
+	setStatusCondition(conditions,
+		*newVRGDataReplicatingCondition(observedGeneration, VRGConditionReasonReplicating, message))
 }
 
-func newVRGDataReplicatingCondition(observedGeneration int64, message string) *metav1.Condition {
+func newVRGDataReplicatingCondition(observedGeneration int64, reason, message string) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
-		Reason:             VRGConditionReasonReplicating,
+		Reason:             reason,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
@@ -169,6 +171,16 @@ func newVRGAsDataProtectedCondition(observedGeneration int64, message string) *m
 	}
 }
 
+func newVRGAsDataProtectedUnusedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Type:               VRGConditionTypeDataProtected,
+		Reason:             VRGConditionReasonUnused,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	}
+}
+
 func setVRGAsDataNotProtectedCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, *newVRGAsDataNotProtectedCondition(observedGeneration, message))
 }
@@ -199,13 +211,13 @@ func newVRGDataProtectionProgressCondition(observedGeneration int64, message str
 
 // sets conditions when Primary VRG data replication is established
 func setVRGAsPrimaryReadyCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
-	setStatusCondition(conditions, *newVRGAsPrimaryReadyCondition(observedGeneration, message))
+	setStatusCondition(conditions, *newVRGAsPrimaryReadyCondition(observedGeneration, VRGConditionReasonReady, message))
 }
 
-func newVRGAsPrimaryReadyCondition(observedGeneration int64, message string) *metav1.Condition {
+func newVRGAsPrimaryReadyCondition(observedGeneration int64, reason, message string) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               VRGConditionTypeDataReady,
-		Reason:             VRGConditionReasonReady,
+		Reason:             reason,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,
@@ -293,6 +305,16 @@ func newVRGClusterDataProtectedCondition(observedGeneration int64, message strin
 	}
 }
 
+func newVRGClusterDataProtectedUnusedCondition(observedGeneration int64, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Type:               VRGConditionTypeClusterDataProtected,
+		Reason:             VRGConditionReasonUnused,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	}
+}
+
 // sets conditions when PV cluster data is being protected
 func setVRGClusterDataProtectingCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, *newVRGClusterDataProtectingCondition(observedGeneration, message))
@@ -368,6 +390,7 @@ func setStatusCondition(existingConditions *[]metav1.Condition, newCondition met
 
 	existingCondition.Reason = newCondition.Reason
 	existingCondition.Message = newCondition.Message
+	// TODO: Why not update lastTranTime if the above change?
 
 	if existingCondition.ObservedGeneration != newCondition.ObservedGeneration {
 		existingCondition.ObservedGeneration = newCondition.ObservedGeneration

--- a/controllers/util/mw_util_test.go
+++ b/controllers/util/mw_util_test.go
@@ -11,36 +11,6 @@ import (
 	ocmworkv1 "github.com/open-cluster-management/api/work/v1"
 	rmnutil "github.com/ramendr/ramen/controllers/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-)
-
-// register Prometheus metrics for testing
-func init() {
-	metrics.Registry.MustRegister(testGauge, testCounter, testHistogram)
-}
-
-var (
-	testGauge = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "ramen_test_gauge",
-		Help: "Test Gauge for use in MW_Util only",
-	})
-
-	testCounter = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: "ramen_test_counter",
-			Help: "Test Counter for use in MW_Util only",
-		},
-	)
-
-	testHistogram = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Name:    "ramen_test_histogram",
-			Help:    "Test Histogram for use in MW_Util only",
-			Buckets: prometheus.ExponentialBuckets(1.0, 2.0, 12),
-		},
-	)
 )
 
 var _ = Describe("IsManifestInAppliedState", func() {

--- a/controllers/volumereplicationgroup_controller.go
+++ b/controllers/volumereplicationgroup_controller.go
@@ -998,6 +998,7 @@ func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
 	result.Requeue = v.reconcileVolRepsAsSecondary() || result.Requeue
 
 	if vrg.Spec.Action == ramendrv1alpha1.VRGActionRelocate {
+		// TODO: If RDSpec changes, and hence generation changes, a k8s backup would be initiated again as Secondary
 		v.relocate(&result)
 	}
 
@@ -1314,6 +1315,14 @@ func (v *VRGInstance) updateLastGroupSyncBytes() {
 	}
 
 	v.instance.Status.LastGroupSyncBytes = totalLastSyncBytes
+}
+
+// isVRGReasonError returns true if the passed in VRG condition reason matches any errors reported as the Reason
+func isVRGReasonError(condition *metav1.Condition) bool {
+	return condition.Reason == VRGConditionReasonError ||
+		condition.Reason == VRGConditionReasonErrorUnknown ||
+		condition.Reason == VRGConditionReasonUploadError ||
+		condition.Reason == VRGConditionReasonClusterDataAnnotationFailed
 }
 
 func (v *VRGInstance) s3StoreAccessorsGet() {

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -271,7 +271,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			vrgTestBoundPV.promoteVolReps()
-			vrgTestBoundPV.verifyVRGStatusExpectation(true)
+			vrgTestBoundPV.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		var pvcNamespacedNamesActual [pvcCount]types.NamespacedName
 		var pvcNamespacedNamesUnqualified, pvcNamespacedNamesQualified []types.NamespacedName
@@ -541,7 +541,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			vrgS3UploadTestCase.promoteVolReps()
-			vrgS3UploadTestCase.verifyVRGStatusExpectation(true)
+			vrgS3UploadTestCase.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 			vrgS3UploadTestCase.verifyCachedUploadError()
 		})
 		Specify("set VRG's S3 profile names to empty", func() {
@@ -575,7 +575,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			vrgVRDeleteEnsureTestCase.promoteVolReps()
-			vrgVRDeleteEnsureTestCase.verifyVRGStatusExpectation(true)
+			vrgVRDeleteEnsureTestCase.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("ensures orderly cleanup post VolumeReplication deletion", func() {
 			By("Protecting the VolumeReplication resources from deletion")
@@ -647,9 +647,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				v := vrgTestCases[c]
 				v.promoteVolReps()
 				if c != 0 {
-					v.verifyVRGStatusExpectation(true)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 				} else {
-					v.verifyVRGStatusExpectation(false)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonUnused)
 				}
 			}
 		})
@@ -680,7 +680,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgEmptySC = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
 		})
 		It("waits for VRG status to match", func() {
-			vrgEmptySC.verifyVRGStatusExpectation(false)
+			vrgEmptySC.verifyVRGStatusExpectation(false, "")
 		})
 		It("cleans up after testing", func() {
 			vrgEmptySC.cleanupStatusAbsent()
@@ -707,7 +707,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 			vrgMissingSC = newVRGTestCaseCreateAndStart(1, createTestTemplate, true, false)
 		})
 		It("waits for VRG status to match", func() {
-			vrgMissingSC.verifyVRGStatusExpectation(false)
+			vrgMissingSC.verifyVRGStatusExpectation(false, "")
 		})
 		It("cleans up after testing", func() {
 			vrgMissingSC.cleanupStatusAbsent()
@@ -767,9 +767,9 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 				v := vrgTests[c]
 				v.promoteVolReps()
 				if c != 0 {
-					v.verifyVRGStatusExpectation(true)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 				} else {
-					v.verifyVRGStatusExpectation(false)
+					v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonUnused)
 				}
 			}
 		})
@@ -816,7 +816,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v.promoteVolReps()
-			v.verifyVRGStatusExpectation(true)
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("protects kube objects", func() { kubeObjectProtectionValidate(vrgStatusTests) })
 		It("cleans up after testing", func() {
@@ -851,7 +851,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		It("waits for VRG status to match", func() {
 			v := vrgStatus2Tests[0]
 			v.promoteVolReps()
-			v.verifyVRGStatusExpectation(true)
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("protects kube objects", func() { kubeObjectProtectionValidate(vrgStatus2Tests) })
 		It("cleans up after testing", func() {
@@ -897,7 +897,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v.promoteVolReps()
-			v.verifyVRGStatusExpectation(true)
+			v.verifyVRGStatusExpectation(true, vrgController.VRGConditionReasonReady)
 		})
 		It("protects kube objects", func() { kubeObjectProtectionValidate(vrgStatus3Tests) })
 		It("cleans up after testing", func() {
@@ -930,7 +930,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v := vrgScheduleTests[0]
-			v.verifyVRGStatusExpectation(false)
+			v.verifyVRGStatusExpectation(false, "")
 		})
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgScheduleTests) })
 		It("cleans up after testing", func() {
@@ -952,7 +952,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		scProvisioner:          "manual.storage.com",
 		replicationClassLabels: map[string]string{"protection": "ramen"},
 	}
-	Context("schedule tests schedue does not match", func() {
+	Context("schedule tests schedule does not match", func() {
 		It("sets up non-bound PVCs, PVs and then bind them", func() {
 			vrgScheduleTest2Template.s3Profiles = []string{s3Profiles[vrgS3ProfileNumber].S3ProfileName}
 			v := newVRGTestCaseCreateAndStart(4, vrgScheduleTest2Template, true, true)
@@ -964,7 +964,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v := vrgSchedule2Tests[0]
-			v.verifyVRGStatusExpectation(false)
+			v.verifyVRGStatusExpectation(false, "")
 		})
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgSchedule2Tests) })
 		It("cleans up after testing", func() {
@@ -998,7 +998,7 @@ var _ = Describe("VolumeReplicationGroupVolRepController", func() {
 		})
 		It("waits for VRG status to match", func() {
 			v := vrgSchedule3Tests[0]
-			v.verifyVRGStatusExpectation(false)
+			v.verifyVRGStatusExpectation(false, "")
 		})
 		// It("protects kube objects", func() { kubeObjectProtectionValidate(vrgSchedule3Tests) })
 		It("cleans up after testing", func() {
@@ -1534,7 +1534,7 @@ func (v *vrgTest) isAnyPVCProtectedByVolSync(vrg *ramendrv1alpha1.VolumeReplicat
 	return false
 }
 
-func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool) {
+func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool, reason string) {
 	Eventually(func() bool {
 		vrg := v.getVRG()
 		dataReadyCondition := meta.FindStatusCondition(
@@ -1548,11 +1548,9 @@ func (v *vrgTest) verifyVRGStatusExpectation(expectedStatus bool) {
 			// secondary. Validate that as well.
 			switch vrg.Spec.ReplicationState {
 			case ramendrv1alpha1.Primary:
-				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason ==
-					vrgController.VRGConditionReasonReady
+				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason == reason
 			case ramendrv1alpha1.Secondary:
-				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason ==
-					vrgController.VRGConditionReasonReplicating
+				return dataReadyCondition.Status == metav1.ConditionTrue && dataReadyCondition.Reason == reason
 			}
 		}
 
@@ -2005,7 +2003,7 @@ func (v *vrgTest) waitForVRCountToMatch(vrCount int) {
 func (v *vrgTest) promoteVolReps() {
 	v.promoteVolRepsAndDo(func(index, count int) {
 		// VRG should not be ready until last VolRep is ready.
-		v.verifyVRGStatusExpectation(index == count-1)
+		v.verifyVRGStatusExpectation(index == count-1, vrgController.VRGConditionReasonReady)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -100,8 +100,4 @@ require (
 // replace directives to accommodate for stolostron
 replace k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.29.0
 
-replace (
-	github.com/open-cluster-management-io/api => open-cluster-management.io/api v0.10.0
-	github.com/openshift/hive => github.com/openshift/hive v1.1.17-0.20220223000051-b1c8fa5853b1
-	github.com/openshift/hive/apis => github.com/openshift/hive/apis v0.0.0-20220221165319-b389a65758da
-)
+replace github.com/open-cluster-management-io/api => open-cluster-management.io/api v0.10.0


### PR DESCRIPTION
Currently workload health is elaborated within DRPC status
as part of the ResourceConditions, which in turn carries
the required VRG status.

This commit adds an explicit condition in DRPC that reflects
workload potected status, which is processed based on VRG
status and its health as reported from the managed cluster
where the workload is expected to be deployed.

Backport from upstream of the following PRs:
https://github.com/RamenDR/ramen/pull/1254
https://github.com/RamenDR/ramen/pull/790
https://github.com/RamenDR/ramen/pull/1316
https://github.com/RamenDR/ramen/pull/1326
https://github.com/RamenDR/ramen/pull/1354