### PR TITLE
Bug 2264435: append condition to set metrics

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -1755,8 +1755,8 @@ func (r *DRPlacementControlReconciler) updateDRPCStatus(
 
 	r.updateResourceCondition(drpc, userPlacement)
 
-	// do not set metrics if DRPC is being deleted
-	if !isBeingDeleted(drpc, userPlacement) {
+	// set metrics if DRPC is not being deleted and if finalizer exists
+	if !isBeingDeleted(drpc, userPlacement) && controllerutil.ContainsFinalizer(drpc, DRPCFinalizer) {
 		if err := r.setDRPCMetrics(ctx, drpc, log); err != nil {
 			// log the error but do not return the error
 			log.Info("Failed to set drpc metrics", "errMSg", err)


### PR DESCRIPTION
Metrics were being set during delete of DRPC. The current check looks if drpc is deleted or not and here the check fails because at that moment drpc might not have deleted because of the ownership references. DRPC might be waiting for the child resources to be deleted. And in one of these instances we find drpc and sets metric with 0 value. Adding a check if finalizers is present ensures that metrics would be set only if finalizer is set. So in the delete scenario drpc would not have finalizers and this check would ensure that we do not set metrics again

Signed-off-by: rakeshgm <rakeshgm@redhat.com>
(cherry picked from commit 446a7de8bca8ac5706a8b050c784f65ca8c999c6)