### PR TITLE
add resources to transformer config

### DIFF
--- a/config/dr-cluster/manifests/idr/kustomization.yaml
+++ b/config/dr-cluster/manifests/idr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-dr-cluster
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml

--- a/config/dr-cluster/manifests/odr/kustomization.yaml
+++ b/config/dr-cluster/manifests/odr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-dr-cluster
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml

--- a/config/hub/manifests/idr/kustomization.yaml
+++ b/config/hub/manifests/idr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-hub
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml

--- a/config/hub/manifests/odr/kustomization.yaml
+++ b/config/hub/manifests/odr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-hub
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml


### PR DESCRIPTION
few of the resources were not present under transformer
configurations and because of this, these resources did have
the label `app: ramen-dr-cluster`. Adding this makes easier to
filter out ramen specific resources and avoids conflict filtering