### PR TITLE
Bug 2280342: add resources to transformer config 

### DIFF
--- a/config/dr-cluster/default/kustomization.yaml
+++ b/config/dr-cluster/default/kustomization.yaml
@@ -31,6 +31,8 @@ transformers:
     path: metadata/labels
   - kind: Service
     path: spec/selector
+  - kind: ConfigMap
+    path: metadata/labels
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/config/dr-cluster/manifests/idr/kustomization.yaml
+++ b/config/dr-cluster/manifests/idr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-dr-cluster
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml

--- a/config/dr-cluster/manifests/odr/kustomization.yaml
+++ b/config/dr-cluster/manifests/odr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-dr-cluster
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml

--- a/config/hub/default/k8s/kustomization.yaml
+++ b/config/hub/default/k8s/kustomization.yaml
@@ -31,7 +31,14 @@ transformers:
     path: metadata/labels
   - kind: Service
     path: spec/selector
-
+  - kind: ServiceMonitor
+    path: metadata/labels
+  - kind: ServiceMonitor
+    path: spec/selector/matchLabels
+  - kind: ConfigMap
+    path: metadata/labels
+  - kind: PrometheusRule
+    path: metadata/labels
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/hub/default/ocp/kustomization.yaml
+++ b/config/hub/default/ocp/kustomization.yaml
@@ -31,6 +31,14 @@ transformers:
     path: metadata/labels
   - kind: Service
     path: spec/selector
+  - kind: ServiceMonitor
+    path: metadata/labels
+  - kind: ServiceMonitor
+    path: spec/selector/matchLabels
+  - kind: ConfigMap
+    path: metadata/labels
+  - kind: PrometheusRule
+    path: metadata/labels  
 
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #-../prometheus

--- a/config/hub/manifests/idr/kustomization.yaml
+++ b/config/hub/manifests/idr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-hub
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml

--- a/config/hub/manifests/odr/kustomization.yaml
+++ b/config/hub/manifests/odr/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     disableNameSuffixHash: true
     labels:
       config.openshift.io/inject-trusted-cabundle: "true"
+      app: ramen-hub
 
 patchesStrategicMerge:
 - manager_openshift_trusted_cabundle.yaml


### PR DESCRIPTION
few of the resources were not present under transformer
configurations and because of this, these resources did have
the label `app: ramen-hub` or `app: ramen-dr-cluster`. Adding this makes easier to
filter out ramen specific resources and avoids conflict filtering