### PR TITLE
Bug 2282284: Don't cleanup nil request

### DIFF
--- a/controllers/vrg_kubeobjects.go
+++ b/controllers/vrg_kubeobjects.go
@@ -609,7 +609,10 @@ func (v *VRGInstance) kubeObjectsRecoveryStartOrResume(
 		}
 
 		log1.Error(err, "Kube objects group recover error")
-		cleanup(request)
+
+		if ok {
+			cleanup(request)
+		}
 
 		result.Requeue = true
 


### PR DESCRIPTION
kubeObjectsRecoveryStartOrResume() error handling is very confusing - the code tries to avoid duplicating error handling in 2 unrelated code paths (ok=true, ok=false), leading to referencing a nil request when ok is false.

We need to refactor this later, for now just skip cleanup if there is nothing to cleanup.

Bug: https://bugzilla.redhat.com/2282284
Signed-off-by: Nir Soffer <nsoffer@redhat.com>
(cherry picked from commit 691062c763c25f3714f514439f1fb8401643b630)