### PR TITLE
Bug 2282284: Help pylint with drenv.commands

### DIFF
--- a/test/drenv/commands.py
+++ b/test/drenv/commands.py
@@ -178,6 +178,10 @@ def stream(proc, input=None, bufsize=32 << 10):
         except BrokenPipeError:
             pass
 
+    # Use only if input is not None, but it helps pylint.
+    input_view = ""
+    input_offset = 0
+
     with _Selector() as sel:
         for f, src in (proc.stdout, OUT), (proc.stderr, ERR):
             if f and not f.closed:
@@ -185,7 +189,6 @@ def stream(proc, input=None, bufsize=32 << 10):
         if input:
             sel.register(proc.stdin, selectors.EVENT_WRITE)
             input_view = memoryview(input.encode())
-            input_offset = 0
 
         while sel.get_map():
             for key, event in sel.select():


### PR DESCRIPTION
Looks like recent change in pylint trigger this incorrect report:

    drenv/commands.py:234:28: E0606: Possibly using variable
    'input_view' before assignment (possibly-used-before-assignment)

This cannot happen since we don't register proc.stdin if input is None, so when we reach this block input_view is assigned. However disabling the check risk missing a real issue in that block.

Lets change the code so pylint can understand it better. This also make it easier to understand for humans. The cost is negligible, adding 2 temporary variables even when they are never used.

Signed-off-by: Nir Soffer <nsoffer@redhat.com>
(cherry picked from commit 797c1a81a5cb653db40bffb15cbbecd3ce3532bc)

Note: this is not related to the linked bug, it fixes the tests by pulling the upstream test fix.