### PR TITLE
Bug 2246638: DRCluster does not clear its condition after it is unfenced

### DIFF
--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -1320,7 +1320,7 @@ func (u *drclusterInstance) createNFManifestWork(targetCluster *ramen.DRCluster,
 	annotations[DRClusterNameAnnotation] = u.object.Name
 
 	if err := u.mwUtil.CreateOrUpdateNFManifestWork(
-		u.object.Name, u.object.Namespace,
+		u.object.Name,
 		peerCluster.Name, nf, annotations); err != nil {
 		log.Error(err, "failed to create or update NetworkFence manifest")
 

--- a/controllers/drcluster_controller.go
+++ b/controllers/drcluster_controller.go
@@ -926,51 +926,9 @@ func (u *drclusterInstance) removeFencingCR(cluster ramen.DRCluster) (bool, erro
 	err := u.mwUtil.DeleteManifestWork(fmt.Sprintf(util.ManifestWorkNameFormat,
 		u.object.Name, cluster.Name, util.MWTypeNF), cluster.Name)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return u.ensureNetworkFenceDeleted(cluster.Name)
-		}
-
 		return true, fmt.Errorf("failed to delete NetworkFence resource from cluster %s", cluster.Name)
 	}
 
-	setDRClusterCleaningCondition(&u.object.Status.Conditions, u.object.Generation, "NetworkFence resource clean started")
-
-	// Since ManifestWork for the fencing CR delete request
-	// has been just issued, requeue is needed to ensure that
-	// the fencing CR has indeed been deleted from the cluster.
-	return true, nil
-}
-
-func (u *drclusterInstance) ensureNetworkFenceDeleted(clusterName string) (bool, error) {
-	annotations := make(map[string]string)
-	annotations[DRClusterNameAnnotation] = u.object.Name
-
-	if _, err := u.reconciler.MCVGetter.GetNFFromManagedCluster(u.object.Name,
-		u.object.Namespace, clusterName, annotations); err != nil {
-		if errors.IsNotFound(err) {
-			return u.deleteNFMCV(clusterName)
-		}
-
-		return true, fmt.Errorf("failed to get MCV for NetworkFence on %s (%w)", clusterName, err)
-	}
-
-	// We are here means, successfully NetworkFence MCV is obtained. Hence
-	// we need to wait for NetworkFence deletion to complete. Requeue.
-	return true, nil
-}
-
-func (u *drclusterInstance) deleteNFMCV(clusterName string) (bool, error) {
-	mcvNameNF := util.BuildManagedClusterViewName(u.object.Name, u.object.Namespace, util.MWTypeNF)
-
-	err := u.reconciler.MCVGetter.DeleteNFManagedClusterView(u.object.Name, u.object.Namespace, clusterName, mcvNameNF)
-	if err != nil {
-		u.log.Info("Failed to delete the MCV for NetworkFence")
-
-		return true, fmt.Errorf("failed to delete MCV for NetworkFence %w", err)
-	}
-
-	u.log.Info("Deleted the MCV for NetworkFence")
-	// successfully deleted the MCV for NetworkFence. No need to requeue
 	return false, nil
 }
 

--- a/controllers/util/mw_util.go
+++ b/controllers/util/mw_util.go
@@ -228,10 +228,10 @@ func ExtractMModeFromManifestWork(mw *ocmworkv1.ManifestWork) (*rmn.MaintenanceM
 
 // NetworkFence MW creation
 func (mwu *MWUtil) CreateOrUpdateNFManifestWork(
-	name, namespace, homeCluster string,
+	name, homeCluster string,
 	nf csiaddonsv1alpha1.NetworkFence, annotations map[string]string,
 ) error {
-	manifestWork, err := mwu.generateNFManifestWork(name, namespace, homeCluster, nf, annotations)
+	manifestWork, err := mwu.generateNFManifestWork(name, homeCluster, nf, annotations)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func (mwu *MWUtil) CreateOrUpdateNFManifestWork(
 	return mwu.createOrUpdateManifestWork(manifestWork, homeCluster)
 }
 
-func (mwu *MWUtil) generateNFManifestWork(name, namespace, homeCluster string,
+func (mwu *MWUtil) generateNFManifestWork(name, homeCluster string,
 	nf csiaddonsv1alpha1.NetworkFence, annotations map[string]string,
 ) (*ocmworkv1.ManifestWork, error) {
 	nfClientManifest, err := mwu.generateNFManifest(nf)
@@ -257,7 +257,7 @@ func (mwu *MWUtil) generateNFManifestWork(name, namespace, homeCluster string,
 	//       that wants to create the csiaddonsv1alpha1.NetworkFence resource
 	// type: type of the resource for this ManifestWork
 	return mwu.newManifestWork(
-		fmt.Sprintf(ManifestWorkNameFormat, name, namespace, MWTypeNF),
+		fmt.Sprintf(ManifestWorkNameFormat, name, homeCluster, MWTypeNF),
 		homeCluster,
 		map[string]string{"app": "NF"},
 		manifests, annotations), nil


### PR DESCRIPTION
The problem:
When a drcluster is fenced or unfenced and the operation is complete, ramen hub operator doesn't delete the manifestwork that it created to perform the operation. The manifestwork is therefore left to be reused for further operations on the same drcluster. When reused in such a manner, it is possible that the result condition from the previous operation is referred to by Ramen as the current state. This leads to a potential data corruption bug where Ramen allows for deployment of the apps on the failover cluster before the failed cluster is completely fenced. 

The solution:
NF manifest work is not deleted after every unfence operation.