### PR TITLE
Bug 2276222: Ignore Secondary VRG Post-HubRecovery to Ensure Proper Reconciliation

### DIFF
--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -2591,7 +2591,10 @@ func (r *DRPlacementControlReconciler) determineDRPCState(
 			break
 		}
 
-		if drpc.Spec.Action != rmn.DRAction(vrg.Spec.Action) &&
+		// Post-HubRecovery, if the retrieved VRG from the surviving cluster is secondary, it wrongly halts
+		// reconciliation for the workload. Only proceed if the retrieved VRG is primary.
+		if vrg.Spec.ReplicationState == rmn.Primary &&
+			drpc.Spec.Action != rmn.DRAction(vrg.Spec.Action) &&
 			dstCluster == clusterName {
 			msg := fmt.Sprintf("Stop - Two different actions for the same cluster - drpcAction:'%s'. vrgAction:'%s'",
 				drpc.Spec.Action, vrg.Spec.Action)


### PR DESCRIPTION
Post-HubRecovery, if the retrieved VRG from the surviving cluster is secondary, reconciliation for the workload is wrongly halted. In this fix, we ignore the secondary VRG when rebuilding the DRPC state to ensure the current action can proceed.

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2276222

Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit 6d4ebf4014a84c8516bd6e145e971bee0f40413c)