### PR TITLE
Bug 2291255: Backport of upstream PR 1444

### DIFF
--- a/api/v1alpha1/ramenconfig_types.go
+++ b/api/v1alpha1/ramenconfig_types.go
@@ -147,7 +147,8 @@ type RamenConfig struct {
 
 	MultiNamespace struct {
 		// Enables feature to protect resources in namespaces other than VRG's
-		FeatureEnabled bool `json:"FeatureEnabled,omitempty"`
+		FeatureEnabled   bool `json:"FeatureEnabled,omitempty"`
+		VolsyncSupported bool `json:"volsyncSupported,omitempty"`
 	} `json:"multiNamespace,omitempty"`
 
 	// Unprotect deleted or deselected PVCs

--- a/controllers/drplacementcontrol_controller.go
+++ b/controllers/drplacementcontrol_controller.go
@@ -979,6 +979,10 @@ func (r *DRPlacementControlReconciler) createDRPCInstance(
 		log.Info("volsync is set to disabled")
 	}
 
+	if !d.volSyncDisabled && drpcInAdminNamespace(drpc, ramenConfig) {
+		d.volSyncDisabled = !ramenConfig.MultiNamespace.VolsyncSupported
+	}
+
 	// Save the instance status
 	d.instance.Status.DeepCopyInto(&d.savedInstanceStatus)
 


### PR DESCRIPTION
drpc: add ramenconfig field to enable volsync support for discovered apps

Add a configuration option that keeps volsync support for discovered apps disabled until the feature is well tested.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>
(cherry picked from commit d3b1b8c3f66f14fa40504e67e0abc98cbf7c46ce)