### PR TITLE
Bug 2284021: Return a valid cluster only if primary VRG is found during initial de…

### DIFF
--- a/controllers/drplacementcontrol.go
+++ b/controllers/drplacementcontrol.go
@@ -276,12 +276,15 @@ func (d *DRPCInstance) getCachedVRG(clusterName string) *rmn.VolumeReplicationGr
 }
 
 func (d *DRPCInstance) isVRGAlreadyDeployedElsewhere(clusterToSkip string) (string, bool) {
-	for clusterName := range d.vrgs {
+	for clusterName, vrg := range d.vrgs {
 		if clusterName == clusterToSkip {
 			continue
 		}
 
-		return clusterName, true
+		// We are checking for the initial deployment. Only return the cluster if the VRG on it is primary.
+		if isVRGPrimary(vrg) {
+			return clusterName, true
+		}
 	}
 
 	return "", false


### PR DESCRIPTION
When the primary cluster is down and the workload is in the initial deployment that is targeted for volsync, the DRPC might mistakenly think the VRG on the secondary cluster is the primary one. This code hasn't changed since VolSync was introduced. The original code expected only one primary VRG between the two clusters. The fix is straightforward: for the initial deployment, only return the cluster if the primary VRG is found; otherwise, return not found.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2284021

Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit 126b5bd4b30bde50578c93715f9f959a59d36e19)