### PR TITLE
Bug 2303823: Upgrading capabilities in the CSVs

### DIFF
--- a/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
+++ b/config/dr-cluster/manifests/bases/ramen_dr_cluster.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: ramen-dr-cluster-operator.v0.0.0
   namespace: placeholder

--- a/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
+++ b/config/hub/manifests/bases/ramen_hub.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     operators.openshift.io/infrastructure-features: '["disconnected"]'
   name: ramen-hub-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
For ramen, the capabilities for hub and
cluster bundles currently states "Basic Install",
Updating it to "Seamless Upgrades".

Fixes: [Bug-2303823](https://bugzilla.redhat.com/show_bug.cgi?id=2303823)
Signed-off-by: Abhijeet Shakya <abhijeetshakya21@gmail.com>
(cherry picked from commit 6f4d9f308317714b3cfc52522844e7bb522556c5)