### PR TITLE
github: automatically label the PRs with matching branches

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+# Add branch labels to the PRs matching their branch names
+branch/main:
+ - base-branch: 'main'
+branch/release-4.14:
+ - base-branch: 'release-4.14'
+branch/release-4.15:
+ - base-branch: 'release-4.15'
+branch/release-4.16:
+ - base-branch: 'release-4.16'
+branch/release-4.17:
+ - base-branch: 'release-4.17'
+branch/release-4.18:
+ - base-branch: 'release-4.18'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+name: label pr
+on:  # yamllint disable-line rule:truthy
+- pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5


### PR DESCRIPTION
It is very hard to identify PRs required for a particular branch without labels. Hopefully this helps.