### PR TITLE
Bug DFBUGS-1520: Fix CG PVC selection issue due to storageId mismatch on failover

### DIFF
--- a/api/v1alpha1/replicationgroupdestination_types.go
+++ b/api/v1alpha1/replicationgroupdestination_types.go
@@ -51,6 +51,7 @@ type ReplicationGroupDestinationStatus struct {
 // +kubebuilder:printcolumn:name="Last sync",type="string",format="date-time",JSONPath=`.status.lastSyncTime`
 // +kubebuilder:printcolumn:name="Duration",type="string",JSONPath=`.status.lastSyncDuration`
 // +kubebuilder:printcolumn:name="Last sync start",type="string",format="date-time",JSONPath=`.status.lastSyncStartTime`
+// +kubebuilder:resource:shortName=rgd
 
 // ReplicationGroupDestination is the Schema for the replicationgroupdestinations API
 type ReplicationGroupDestination struct {

--- a/api/v1alpha1/replicationgroupsource_types.go
+++ b/api/v1alpha1/replicationgroupsource_types.go
@@ -72,6 +72,7 @@ type ReplicationGroupSourceStatus struct {
 // +kubebuilder:printcolumn:name="Next sync",type="string",format="date-time",JSONPath=`.status.nextSyncTime`
 // +kubebuilder:printcolumn:name="Source",type="string",JSONPath=`.spec.volumeGroupSnapshotSource`
 // +kubebuilder:printcolumn:name="Last sync start",type="string",format="date-time",JSONPath=`.status.lastSyncStartTime`
+// +kubebuilder:resource:shortName=rgs
 
 // ReplicationGroupSource is the Schema for the replicationgroupsources API
 type ReplicationGroupSource struct {

--- a/config/crd/bases/ramendr.openshift.io_replicationgroupdestinations.yaml
+++ b/config/crd/bases/ramendr.openshift.io_replicationgroupdestinations.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ReplicationGroupDestination
     listKind: ReplicationGroupDestinationList
     plural: replicationgroupdestinations
+    shortNames:
+    - rgd
     singular: replicationgroupdestination
   scope: Namespaced
   versions:

--- a/config/crd/bases/ramendr.openshift.io_replicationgroupsources.yaml
+++ b/config/crd/bases/ramendr.openshift.io_replicationgroupsources.yaml
@@ -11,6 +11,8 @@ spec:
     kind: ReplicationGroupSource
     listKind: ReplicationGroupSourceList
     plural: replicationgroupsources
+    shortNames:
+    - rgs
     singular: replicationgroupsource
   scope: Namespaced
   versions:

--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -245,7 +245,6 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 
 		return nil, false, err
 	}
-
 	//
 	// For final sync only - check status to make sure the final sync is complete
 	// and also run cleanup (removes PVC we just ran the final sync from)

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -741,38 +741,44 @@ func (v *VRGInstance) labelPVCsForCG() error {
 }
 
 func (v *VRGInstance) addConsistencyGroupLabel(pvc *corev1.PersistentVolumeClaim) error {
-	scName := pvc.Spec.StorageClassName
+	cgLabelVal, err := v.getCGLabelValue(pvc.Spec.StorageClassName, pvc.GetName(), pvc.GetNamespace())
+	if err != nil {
+		return err
+	}
 
+	// Add a CG label to indicate that this PVC belongs to a consistency group.
+	return util.NewResourceUpdater(pvc).
+		AddLabel(ConsistencyGroupLabel, cgLabelVal).
+		Update(v.ctx, v.reconciler.Client)
+}
+
+func (v *VRGInstance) getCGLabelValue(scName *string, pvcName, pvcNamespace string) (string, error) {
 	if scName == nil || *scName == "" {
-		return fmt.Errorf("missing storage class name for PVC %s/%s", pvc.GetNamespace(), pvc.GetName())
+		return "", fmt.Errorf("missing storage class name for PVC %s/%s", pvcNamespace, pvcName)
 	}
 
 	storageClass := &storagev1.StorageClass{}
 	if err := v.reconciler.Get(v.ctx, types.NamespacedName{Name: *scName}, storageClass); err != nil {
 		v.log.Info(fmt.Sprintf("Failed to get the storageclass %s", *scName))
 
-		return fmt.Errorf("failed to get the storageclass with name %s (%w)", *scName, err)
+		return "", fmt.Errorf("failed to get the storageclass with name %s (%w)", *scName, err)
 	}
 
 	storageID, ok := storageClass.GetLabels()[StorageIDLabel]
 	if !ok {
-		v.log.Info("Missing storageID for PVC %s/%s", pvc.GetNamespace(), pvc.GetName())
+		v.log.Info("Missing storageID for PVC %s/%s", pvcNamespace, pvcName)
 
-		return fmt.Errorf("missing storageID for PVC %s/%s", pvc.GetNamespace(), pvc.GetName())
+		return "", fmt.Errorf("missing storageID for PVC %s/%s", pvcNamespace, pvcName)
 	}
 
 	// FIXME: a temporary workaround for issue DFBUGS-1209
 	// Remove this block once DFBUGS-1209 is fixed
-	if storageClass.Provisioner == DefaultCephFSCSIDriverName {
-		storageID = "cephfs-" + storageID
-	} else {
-		storageID = "rbd-" + storageID
+	cgLabelVal := "cephfs-" + storageID
+	if storageClass.Provisioner != DefaultCephFSCSIDriverName {
+		cgLabelVal = "rbd-" + storageID
 	}
 
-	// Add label for PVC, showing that this PVC is part of consistency group
-	return util.NewResourceUpdater(pvc).
-		AddLabel(ConsistencyGroupLabel, storageID).
-		Update(v.ctx, v.reconciler.Client)
+	return cgLabelVal, nil
 }
 
 func (v *VRGInstance) updateReplicationClassList() error {


### PR DESCRIPTION
Recently, we started using storageId as part of the label to determine whether a PVC belongs to a consistency group. While the initial deployment and synchronization from primary to secondary clusters work correctly, failover or relocation results in a different storageId on the new primary.

This mismatch causes issues when setting up the source and destination again. This fix ensures that PVC selection accounts for storageId differences to maintain correct CG membership during failover and relocation.

Signed-off-by: Benamar Mekhissi <bmekhiss@ibm.com>
(cherry picked from commit 3f02d83be46173f96baf78d3f120dfabda3562bc)