### PR TITLE
DFBUGS-1798: Shorten Volsync Job Name if exceeds 63 characters

### DIFF
--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -2006,7 +2006,7 @@ func getLocalServiceNameForRDFromPVCName(pvcName string) string {
 
 func getLocalServiceNameForRD(rdName string) string {
 	// This is the name VolSync will use for the service
-	return fmt.Sprintf("volsync-rsync-tls-dst-%s", rdName)
+	return util.GetServiceName("volsync-rsync-tls-dst-", rdName)
 }
 
 // This is the remote service name that can be accessed from another cluster.  This assumes submariner and that
@@ -2551,7 +2551,7 @@ func (v *VSHandler) removeOCMAnnotationsAndUpdate(obj client.Object) error {
 func (v *VSHandler) IsActiveJobPresent(name, namespace string) (bool, error) {
 	namespacedName := types.NamespacedName{
 		Namespace: namespace,
-		Name:      fmt.Sprintf("volsync-rsync-tls-src-%s", name),
+		Name:      util.GetJobName("volsync-rsync-tls-src-", name),
 	}
 
 	job := &batchv1.Job{}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/DFBUGS-513
Also related to: https://github.com/backube/volsync/issues/1470

The problem:
When replicating a Protected Application volumes via Volsync within the context of ACM Disaster recovery/Enroll Application/Discovered Application, it appears Volsync pre-pends "volsync-" when generating replicated PVC and "volsync-rsync-tls-src-" when generating Volsync Job/Pod names. The additional characters result in the error/failure within the corresponding ReplicationSource CR.

The solution:
Shorten PVC name in the job/service name

Signed-off-by: Elena Gershkovich <elenage@il.ibm.com>
(cherry picked from commit 0d7dce1e2dd78e460b384814c6db5b0f9f29db52)