### PR TITLE
DFBUGS-1777: Fix for panic observed while processing VRG

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1591,6 +1591,11 @@ func updatePeers(
 	peerClasses := vrgPeerClasses
 
 	for pvcIdx := range vrgFromView.Status.ProtectedPVCs {
+		if vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName == nil ||
+			len(*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName) == 0 {
+			continue
+		}
+
 		for policyPeerClassIdx := range policyPeerClasses {
 			if policyPeerClasses[policyPeerClassIdx].StorageClassName ==
 				*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName {


### PR DESCRIPTION
Fixes panic due to nil StorageClassName in ProtectedPVC list processing.

This can occur if a PVC is using a StorageClass that is not in the passed in peerClass list to VRG.

Signed-off-by: pruthvitd <prd@redhat.com>
(cherry picked from commit 48de30e6d28475102055ba986556e40ceba6597a)