### PR TITLE
DFBUGS-1866: Update VRG peerClass with updated storage and replication IDs

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1569,6 +1569,34 @@ func (d *DRPCInstance) ensureVRGManifestWork(homeCluster string) error {
 	return d.mwu.UpdateVRGManifestWork(vrg, mw)
 }
 
+// updatePeerClass conditionally updates an existing peerClass in to, with values from. If existing peerClass claims
+// a replicationID then the from should also claim a replicationID, else both should not. This ensures that a peerClass
+// is updated with latest storage/replication IDs, but only if the underlying replication scheme remains unchanged.
+func updatePeerClass(log logr.Logger, to []rmn.PeerClass, from rmn.PeerClass, scName string) {
+	for toIdx := range to {
+		if (to[toIdx].StorageClassName != scName) ||
+			(!slices.Equal(to[toIdx].ClusterIDs, from.ClusterIDs)) {
+			continue
+		}
+
+		if to[toIdx].ReplicationID == "" && from.ReplicationID == "" {
+			to[toIdx] = from
+
+			break
+		}
+
+		if to[toIdx].ReplicationID != "" && from.ReplicationID != "" {
+			to[toIdx] = from
+
+			break
+		}
+
+		log.Info("Unable to update mismatching peerClass", "peerClass", to[toIdx], "from", from)
+
+		break
+	}
+}
+
 // hasPeerClass finds a peer in the passed in list of peerClasses and returns true if a peer matches the passed in
 // storage class name and represents the cluster in the clusterIDs list
 // Also see peerClassMatchesPeer
@@ -1585,6 +1613,7 @@ func hasPeerClass(vrgPeerClasses []rmn.PeerClass, scName string, clusterIDs []st
 
 // updatePeers see updateVRGDRTypeSpec
 func updatePeers(
+	log logr.Logger,
 	vrgFromView *rmn.VolumeReplicationGroup,
 	vrgPeerClasses, policyPeerClasses []rmn.PeerClass,
 ) []rmn.PeerClass {
@@ -1592,21 +1621,38 @@ func updatePeers(
 
 	for pvcIdx := range vrgFromView.Status.ProtectedPVCs {
 		for policyPeerClassIdx := range policyPeerClasses {
-			if policyPeerClasses[policyPeerClassIdx].StorageClassName ==
+			if policyPeerClasses[policyPeerClassIdx].StorageClassName !=
 				*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName {
-				if hasPeerClass(
-					vrgPeerClasses,
-					*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName,
-					policyPeerClasses[policyPeerClassIdx].ClusterIDs,
-				) {
-					break
-				}
+				continue
+			}
 
-				peerClasses = append(
+			if hasPeerClass(
+				vrgPeerClasses,
+				*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName,
+				policyPeerClasses[policyPeerClassIdx].ClusterIDs,
+			) {
+				updatePeerClass(
+					log,
 					peerClasses,
 					policyPeerClasses[policyPeerClassIdx],
+					*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName,
 				)
+
+				break
 			}
+
+			if hasPeerClass(
+				peerClasses,
+				*vrgFromView.Status.ProtectedPVCs[pvcIdx].StorageClassName,
+				policyPeerClasses[policyPeerClassIdx].ClusterIDs,
+			) {
+				break
+			}
+
+			peerClasses = append(
+				peerClasses,
+				policyPeerClasses[policyPeerClassIdx],
+			)
 		}
 	}
 
@@ -1636,7 +1682,12 @@ func (d *DRPCInstance) updateVRGAsyncSpec(vrgFromView, vrg *rmn.VolumeReplicatio
 		return
 	}
 
-	asyncSpec.PeerClasses = updatePeers(vrgFromView, vrg.Spec.Async.PeerClasses, d.drPolicy.Status.Async.PeerClasses)
+	asyncSpec.PeerClasses = updatePeers(
+		d.log,
+		vrgFromView,
+		vrg.Spec.Async.PeerClasses,
+		d.drPolicy.Status.Async.PeerClasses,
+	)
 
 	// TODO: prune peerClasses not in policy and not in use by VRG
 
@@ -1666,7 +1717,7 @@ func (d *DRPCInstance) updateVRGSyncSpec(vrgFromView, vrg *rmn.VolumeReplication
 		return
 	}
 
-	syncSpec.PeerClasses = updatePeers(vrgFromView, vrg.Spec.Sync.PeerClasses, d.drPolicy.Status.Sync.PeerClasses)
+	syncSpec.PeerClasses = updatePeers(d.log, vrgFromView, vrg.Spec.Sync.PeerClasses, d.drPolicy.Status.Sync.PeerClasses)
 
 	// TODO: prune peerClasses not in policy and not in use by VRG
 

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1728,11 +1728,11 @@ func (d *DRPCInstance) updateVRGSyncSpec(vrgFromView, vrg *rmn.VolumeReplication
 // Update works to ensure VRG is updated with peerClasses that it requires, based on reported PVCs that the VRG is
 // attempting to protect. If a VRG is attempting to protect a PVC for which is is lacking a peerClass and that is
 // available as part of the DRPolicy its peerClasses are updated. For existing peerClasses the VRG information is
-// not updated, this is done to avoid any protection mechanism conflicts. For example, if a VRG carried a peerClass
-// without the replicationID (ie it would choose to protect the PVC using Volsync and VolumeSnapshots), then it is not
-// updated with a peerClass that NOW supports native VolumeReplication, as that would void existing protection.
-// To change replication schemes a workload needs to be DR disabled and then reenabled to catch up to the latest
-// available peer information for an SC.
+// updated conditionally (see updatePeerClass), this is done to avoid any protection mechanism conflicts.
+// For example, if a VRG carried a peerClass without the replicationID (ie it would choose to protect the PVC using
+// Volsync and VolumeSnapshots), then it is not updated with a peerClass that NOW supports native VolumeReplication,
+// as that would void existing protection. To change replication schemes a workload needs to be DR disabled and then
+// reenabled to catch up to the latest available peer information for an SC.
 func (d *DRPCInstance) updateVRGDRTypeSpec(vrgFromCluster, generatedVRG *rmn.VolumeReplicationGroup) {
 	switch d.drType {
 	case DRTypeSync:

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -1569,13 +1569,39 @@ func (d *DRPCInstance) ensureVRGManifestWork(homeCluster string) error {
 	return d.mwu.UpdateVRGManifestWork(vrg, mw)
 }
 
+// equalClusterIDSlices compares 2 slices of clusterID strings and reports true if both contain the same clusterIDs.
+// This is not a generic routine that can be used for any pair of string slices for equality checks, as a case of,
+// - ["a", "b", "b"] compared to ["b", "a", "a"], would return true
+// It is used for clusterIDs with the limitation, because clusterIDs are based on UUIDs and collision has ignorable
+// probability
+func equalClusterIDSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, v := range b {
+		if !slices.Contains(a, v) {
+			return false
+		}
+	}
+
+	// check the other way to ensure there are no extra elements in a that are not contained in b
+	for _, v := range a {
+		if !slices.Contains(b, v) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // updatePeerClass conditionally updates an existing peerClass in to, with values from. If existing peerClass claims
 // a replicationID then the from should also claim a replicationID, else both should not. This ensures that a peerClass
 // is updated with latest storage/replication IDs, but only if the underlying replication scheme remains unchanged.
 func updatePeerClass(log logr.Logger, to []rmn.PeerClass, from rmn.PeerClass, scName string) {
 	for toIdx := range to {
 		if (to[toIdx].StorageClassName != scName) ||
-			(!slices.Equal(to[toIdx].ClusterIDs, from.ClusterIDs)) {
+			(!equalClusterIDSlices(to[toIdx].ClusterIDs, from.ClusterIDs)) {
 			continue
 		}
 
@@ -1603,7 +1629,7 @@ func updatePeerClass(log logr.Logger, to []rmn.PeerClass, from rmn.PeerClass, sc
 func hasPeerClass(vrgPeerClasses []rmn.PeerClass, scName string, clusterIDs []string) bool {
 	for peerClassVRGIdx := range vrgPeerClasses {
 		if (vrgPeerClasses[peerClassVRGIdx].StorageClassName == scName) &&
-			(slices.Equal(vrgPeerClasses[peerClassVRGIdx].ClusterIDs, clusterIDs)) {
+			(equalClusterIDSlices(vrgPeerClasses[peerClassVRGIdx].ClusterIDs, clusterIDs)) {
 			return true
 		}
 	}

--- a/internal/controller/drplacementcontrol_watcher.go
+++ b/internal/controller/drplacementcontrol_watcher.go
@@ -280,13 +280,16 @@ func DRClusterUpdateOfInterest(oldDRCluster, newDRCluster *rmn.DRCluster) bool {
 }
 
 // RequiresDRPCReconciliation determines if the updated DRPolicy resource, compared to the previous version,
-// requires reconciliation of the DRPCs. Reconciliation is needed if the DRPolicy has been newly activated.
+// requires reconciliation of the DRPCs. Reconciliation is needed if the DRPolicy has been newly activated, or
+// peerClasses have been updated in the DRPolicy status.
 // This check helps avoid delays in reconciliation by ensuring timely updates when necessary.
 func RequiresDRPCReconciliation(oldDRPolicy, newDRPolicy *rmn.DRPolicy) bool {
 	err1 := rmnutil.DrpolicyValidated(oldDRPolicy)
 	err2 := rmnutil.DrpolicyValidated(newDRPolicy)
 
-	return err1 != err2
+	return err1 != err2 ||
+		!reflect.DeepEqual(oldDRPolicy.Status.Async.PeerClasses, newDRPolicy.Status.Async.PeerClasses) ||
+		!reflect.DeepEqual(oldDRPolicy.Status.Sync.PeerClasses, newDRPolicy.Status.Sync.PeerClasses)
 }
 
 // checkFailoverActivation checks if provided provisioner and storage instance is activated as per the

--- a/internal/controller/drpolicy_peerclass.go
+++ b/internal/controller/drpolicy_peerclass.go
@@ -58,7 +58,7 @@ func peerClassMatchesPeer(pc ramen.PeerClass, peer peerInfo) bool {
 		return false
 	}
 
-	if !slices.Equal(pc.ClusterIDs, peer.clusterIDs) {
+	if !equalClusterIDSlices(pc.ClusterIDs, peer.clusterIDs) {
 		return false
 	}
 

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -62,7 +62,9 @@ const (
 	VRGConditionReasonDataProtected               = "DataProtected"
 	VRGConditionReasonProgressing                 = "Progressing"
 	VRGConditionReasonClusterDataRestored         = "Restored"
+	VRGConditionReasonClusterDataUnused           = "Unused"
 	VRGConditionReasonKubeObjectsRestored         = "KubeObjectsRestored"
+	VRGConditionReasonKubeObjectsUnused           = "Unused"
 	VRGConditionReasonError                       = "Error"
 	VRGConditionReasonErrorUnknown                = "UnknownError"
 	VRGConditionReasonUploading                   = "Uploading"
@@ -319,6 +321,17 @@ func setVRGClusterDataReadyCondition(conditions *[]metav1.Condition, observedGen
 	})
 }
 
+// Used to set condition when VRG is Secondary
+func setVRGClusterDataReadyConditionUnused(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeClusterDataReady,
+		Reason:             VRGConditionReasonClusterDataUnused,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
 // sets conditions when PV cluster data failed to restore
 func setVRGClusterDataErrorCondition(conditions *[]metav1.Condition, observedGeneration int64, message string) {
 	setStatusCondition(conditions, metav1.Condition{
@@ -392,6 +405,17 @@ func setVRGKubeObjectsReadyCondition(conditions *[]metav1.Condition, observedGen
 	setStatusCondition(conditions, metav1.Condition{
 		Type:               VRGConditionTypeKubeObjectsReady,
 		Reason:             VRGConditionReasonKubeObjectsRestored,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+// Used to set condition when VRG is Secondary
+func setVRGKubeObjectsReadyConditionUnused(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	setStatusCondition(conditions, metav1.Condition{
+		Type:               VRGConditionTypeKubeObjectsReady,
+		Reason:             VRGConditionReasonKubeObjectsUnused,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionTrue,
 		Message:            message,

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1220,25 +1220,42 @@ func (v *VRGInstance) processAsPrimary() ctrl.Result {
 
 func (v *VRGInstance) shouldRestoreClusterData() bool {
 	if v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync {
-		msg := "PV restore skipped, as VRG is orchestrating final sync"
-		setVRGClusterDataReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, msg)
+		setVRGClusterDataReadyCondition(
+			&v.instance.Status.Conditions,
+			v.instance.Generation,
+			"PV and PVC restore skipped, as VRG is orchestrating final sync",
+		)
 
 		return false
 	}
 
 	clusterDataReady := findCondition(v.instance.Status.Conditions, VRGConditionTypeClusterDataReady)
-	if clusterDataReady != nil {
-		v.log.Info("ClusterDataReady condition",
-			"status", clusterDataReady.Status,
-			"reason", clusterDataReady.Reason,
-			"message", clusterDataReady.Message,
-			"observedGeneration", clusterDataReady.ObservedGeneration,
-			"generation", v.instance.Generation,
-		)
+	if clusterDataReady == nil {
+		return true
+	}
 
-		if clusterDataReady.Status == metav1.ConditionTrue &&
-			clusterDataReady.ObservedGeneration == v.instance.Generation {
-			v.log.Info("VRG's ClusterDataReady condition found. PV restore must have already been applied")
+	v.log.Info("ClusterDataReady condition",
+		"status", clusterDataReady.Status,
+		"reason", clusterDataReady.Reason,
+		"message", clusterDataReady.Message,
+		"observedGeneration", clusterDataReady.ObservedGeneration,
+		"generation", v.instance.Generation,
+	)
+
+	if clusterDataReady.Status == metav1.ConditionTrue {
+		if clusterDataReady.ObservedGeneration == v.instance.Generation {
+			return false
+		}
+
+		// If generation is older, and reason is restored, then skip the restore. Reason is updated as Secondary to
+		// ensure that a VRG that is changed from Secondary to Primary would perform the restore initially.
+		// Also, update the condition such that a newer generation is recorded.
+		if clusterDataReady.Reason == VRGConditionReasonClusterDataRestored {
+			setVRGClusterDataReadyCondition(
+				&v.instance.Status.Conditions,
+				v.instance.Generation,
+				"PV and PVC restore skipped, an older generation as Primary has already applied the restore",
+			)
 
 			return false
 		}
@@ -1249,25 +1266,42 @@ func (v *VRGInstance) shouldRestoreClusterData() bool {
 
 func (v *VRGInstance) shouldRestoreKubeObjects() bool {
 	if v.instance.Spec.PrepareForFinalSync || v.instance.Spec.RunFinalSync {
-		msg := "kube objects restore skipped, as VRG is orchestrating final sync"
-		setVRGKubeObjectsReadyCondition(&v.instance.Status.Conditions, v.instance.Generation, msg)
+		setVRGKubeObjectsReadyCondition(
+			&v.instance.Status.Conditions,
+			v.instance.Generation,
+			"k8s resource restore skipped, as VRG is orchestrating final sync",
+		)
 
 		return false
 	}
 
 	KubeObjectsRestored := findCondition(v.instance.Status.Conditions, VRGConditionTypeKubeObjectsReady)
-	if KubeObjectsRestored != nil {
-		v.log.Info("KubeObjectsReady condition",
-			"status", KubeObjectsRestored.Status,
-			"reason", KubeObjectsRestored.Reason,
-			"message", KubeObjectsRestored.Message,
-			"observedGeneration", KubeObjectsRestored.ObservedGeneration,
-			"generation", v.instance.Generation,
-		)
+	if KubeObjectsRestored == nil {
+		return true
+	}
 
-		if KubeObjectsRestored.Status == metav1.ConditionTrue &&
-			KubeObjectsRestored.ObservedGeneration == v.instance.Generation {
-			v.log.Info("VRG's KubeObjectsReady condition found. All kube objects must have already been restored")
+	v.log.Info("KubeObjectsReady condition",
+		"status", KubeObjectsRestored.Status,
+		"reason", KubeObjectsRestored.Reason,
+		"message", KubeObjectsRestored.Message,
+		"observedGeneration", KubeObjectsRestored.ObservedGeneration,
+		"generation", v.instance.Generation,
+	)
+
+	if KubeObjectsRestored.Status == metav1.ConditionTrue {
+		if KubeObjectsRestored.ObservedGeneration == v.instance.Generation {
+			return false
+		}
+
+		// If generation is older, and reason is restored, then skip the restore. Reason is updated as Secondary to
+		// ensure that a VRG that is changed from Secondary to Primary would perform the restore initially.
+		// Also, update the condition such that a newer generation is recorded.
+		if KubeObjectsRestored.Reason == VRGConditionReasonKubeObjectsRestored {
+			setVRGKubeObjectsReadyCondition(
+				&v.instance.Status.Conditions,
+				v.instance.Generation,
+				"k8s resource restore skipped, an older generation as Primary has already applied the restore",
+			)
 
 			return false
 		}
@@ -1366,6 +1400,12 @@ func (v *VRGInstance) processAsSecondary() ctrl.Result {
 
 	v.instance.Status.LastGroupSyncTime = nil
 
+	if v.resetInitialStatusAsSecondary() {
+		v.result.Requeue = true
+
+		return v.result
+	}
+
 	result := v.reconcileAsSecondary()
 
 	// If requeue is false, then VRG was successfully processed as Secondary.
@@ -1401,6 +1441,41 @@ func (v *VRGInstance) reconcileAsSecondary() ctrl.Result {
 	}
 
 	return result
+}
+
+// resetInitialStatusAsSecondary resets required initial conditions to start processing VRG as Secondary, if these are
+// updated, VRG needs to be requeued for a reconcile to ensure the updates are preserved before further processing.
+func (v *VRGInstance) resetInitialStatusAsSecondary() bool {
+	clusterDataReady := findCondition(v.instance.Status.Conditions, VRGConditionTypeClusterDataReady)
+	kubeObjectsReady := findCondition(v.instance.Status.Conditions, VRGConditionTypeKubeObjectsReady)
+
+	update := false
+	if clusterDataReady == nil || clusterDataReady.Reason != VRGConditionReasonClusterDataUnused {
+		update = true
+	}
+
+	if kubeObjectsReady == nil || kubeObjectsReady.Reason != VRGConditionReasonClusterDataUnused {
+		update = true
+	}
+
+	// Set the conditions to the current generation irresepective of update required
+	setVRGClusterDataReadyConditionUnused(
+		&v.instance.Status.Conditions,
+		v.instance.Generation,
+		"PV and PVC restore skipped as Secondary",
+	)
+
+	setVRGKubeObjectsReadyConditionUnused(
+		&v.instance.Status.Conditions,
+		v.instance.Generation,
+		"k8s resource restore skipped as Secondary",
+	)
+
+	if update {
+		v.updateVRGStatus(v.result)
+	}
+
+	return update
 }
 
 func (v *VRGInstance) invalid(err error, msg string, requeue bool) ctrl.Result {


### PR DESCRIPTION
VRG peerClass is never updated if an existing peerClass in VRG has
newer changes in DRPolicy. This is to ensure the VRG treats PVCs
using the peerClass as either volsync or volrep, and not switch
between the 2 in case one of the schemes was added or removed later.

If the replication scheme in a peerClass update to DRPolicy remains
unchanged, but the backing storage or replication IDs change, the VRG
peerClass can be safely updated.

This commit introduces such a change, to adapt to potentially changing
backend storage and replication IDs.

Further, VRG peerClass was appended with the same peerClass, if it
was found missing, for every PVC that referenced the class. This
caused duplicate entries in the peerClass list, and has been corrected.