### PR TITLE
DFBUGS-1866: Ensure and update VRG optional fields when processing actions

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -366,6 +366,13 @@ func (d *DRPCInstance) RunFailover() (bool, error) {
 		addOrUpdateCondition(&d.instance.Status.Conditions, rmn.ConditionAvailable, d.instance.Generation,
 			metav1.ConditionTrue, string(d.instance.Status.Phase), "Completed")
 
+		if err := d.ensureVRGManifestWork(failoverCluster); err != nil {
+			d.log.Info("Unable to ensure VRG ManifestWork on failover cluster")
+			d.setProgression(rmn.ProgressionWaitForReadiness)
+
+			return !done, err
+		}
+
 		// Make sure VolRep 'Data' and VolSync 'setup' conditions are ready
 		ready := d.checkReadiness(failoverCluster)
 		if !ready {
@@ -817,7 +824,7 @@ func checkActivationForStorageIdentifier(
 //   - Check if current primary (that is not the preferred cluster), is ready to switch over
 //   - Relocate!
 //
-//nolint:gocognit,cyclop,funlen
+//nolint:gocognit,cyclop,funlen,gocyclo
 func (d *DRPCInstance) RunRelocate() (bool, error) {
 	d.log.Info("Entering RunRelocate", "state", d.getLastDRState(), "progression", d.getProgression())
 
@@ -847,6 +854,13 @@ func (d *DRPCInstance) RunRelocate() (bool, error) {
 	if curHomeCluster != "" && d.vrgExistsAndPrimary(preferredCluster) {
 		d.setDRState(rmn.Relocating)
 		d.updatePreferredDecision()
+
+		if err := d.ensureVRGManifestWork(preferredCluster); err != nil {
+			d.log.Info("Unable to ensure VRG ManifestWork on preferred cluster")
+			d.setProgression(rmn.ProgressionWaitForReadiness)
+
+			return !done, err
+		}
 
 		ready := d.checkReadiness(preferredCluster)
 		if !ready {


### PR DESCRIPTION
It is possible that VRG optional fields (like peer classes) need an update (usually post upgrade, or due to changes in peer class IDs on the clusters), during processing an action.

Currently we update it only post processing the action in full, and in case the optional fields are limiting this progress due to changes, the action remains stuck in WaitForReadiness.

This change ensures that VRG is up to date, even when waiting for readiness during actions.

Signed-off-by: Shyamsundar Ranganathan <srangana@redhat.com>
(cherry picked from commit 55274bf370eb05b0d082da25fa5354bca6eaf983)