### PR TITLE
DFBUGS-1601: Stops unnecessary reconciliation on secondary vrg.

### DIFF
--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -200,10 +200,14 @@ func (d *DRPCInstance) resetRDSpec(srcVRG, dstVRG *rmn.VolumeReplicationGroup,
 			continue
 		}
 
+		protectedPVC.LastSyncBytes = nil
+		protectedPVC.LastSyncTime = nil
+		protectedPVC.LastSyncDuration = nil
+		protectedPVC.Conditions = nil
+
 		rdSpec := rmn.VolSyncReplicationDestinationSpec{
 			ProtectedPVC: protectedPVC,
 		}
-
 		dstVRG.Spec.VolSync.RDSpec = append(dstVRG.Spec.VolSync.RDSpec, rdSpec)
 	}
 }


### PR DESCRIPTION
Fixes [Unnecessary Reconciliation Triggered by Frequent LastSyncTime Updates](https://issues.redhat.com/browse/DFBUGS-1601)


(cherry picked from commit 18649829c91f2a9bc902960131cb016cb69c13af)