### PR TITLE
DFBUGS-2106: recipe: inverseOp addition for exec hooks

### DIFF
--- a/internal/controller/hooks/check_hook.go
+++ b/internal/controller/hooks/check_hook.go
@@ -33,14 +33,14 @@ func (c CheckHook) Execute(log logr.Logger) error {
 	hookName := c.Hook.Name + "/" + c.Hook.Chk.Name
 	log.Info("check hook executed successfully", "hook", hookName, "result", hookResult)
 
-	if !hookResult && shouldHookBeFailedOnError(c.Hook) {
+	if !hookResult && shouldChkHookBeFailedOnError(c.Hook) {
 		return fmt.Errorf("stopping workflow as hook %s failed", c.Hook.Name)
 	}
 
 	return nil
 }
 
-func shouldHookBeFailedOnError(hook *kubeobjects.HookSpec) bool {
+func shouldChkHookBeFailedOnError(hook *kubeobjects.HookSpec) bool {
 	// hook.Check.OnError overwrites the feature of hook.OnError -- defaults to fail
 	if hook.Chk.OnError != "" && hook.Chk.OnError == "continue" {
 		return false

--- a/internal/controller/hooks/exec_hook.go
+++ b/internal/controller/hooks/exec_hook.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+	"github.com/ramendr/ramen/internal/controller/util"
+	recipev1 "github.com/ramendr/recipe/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,9 +29,10 @@ import (
 )
 
 type ExecHook struct {
-	Hook   *kubeobjects.HookSpec
-	Reader client.Reader
-	Scheme *runtime.Scheme
+	Hook           *kubeobjects.HookSpec
+	Reader         client.Reader
+	Scheme         *runtime.Scheme
+	RecipeElements util.RecipeElements
 }
 
 type ExecPodSpec struct {
@@ -47,15 +50,125 @@ func (e ExecHook) Execute(log logr.Logger) error {
 	}
 
 	execPods := e.GetPodsToExecuteCommands(log)
+	inverseOp := e.Hook.Op.InverseOp
 
-	for _, execPod := range execPods {
-		err := executeCommand(&execPod, e.Hook, e.Scheme, log)
-		if err != nil && getOpHookOnError(e.Hook) == defaultOnErrorValue {
-			return fmt.Errorf("error executing exec hook: %w", err)
+	_, err := e.executeCommands(execPods, log)
+	if shouldInverseOpBeExecuted(inverseOp, e.Hook, err) {
+		e.executeInverseOp(inverseOp, log)
+
+		return err
+	}
+
+	return nil
+}
+
+func (e ExecHook) executeInverseOp(inverseOp string, log logr.Logger) {
+	var err error
+
+	var inverseExecPod ExecPodSpec
+
+	hookSpecForInvHook := e.getHookSpecForInverseOp(inverseOp)
+	if hookSpecForInvHook != nil {
+		log.Info("executing inverse operation", "inverseOp", inverseOp, "namespace", hookSpecForInvHook.Namespace)
+
+		tempE := ExecHook{
+			Hook:           hookSpecForInvHook,
+			Reader:         e.Reader,
+			Scheme:         e.Scheme,
+			RecipeElements: e.RecipeElements,
+		}
+
+		execPods := tempE.GetPodsToExecuteCommands(log)
+		inverseExecPod, err = tempE.executeCommands(execPods, log)
+	}
+
+	if hookSpecForInvHook == nil {
+		log.Error(err, "inverse operation not found in recipe", "inverseOp", inverseOp)
+	}
+
+	if err != nil {
+		log.Error(err, "error executing inverse operation", "inverseOp", inverseOp, "pod", inverseExecPod.PodName,
+			"namespace", inverseExecPod.Namespace, "command", inverseExecPod.Command)
+	}
+
+	log.Info("executed inverse operation successfully", "inverseOp", inverseOp, "pod", inverseExecPod.PodName,
+		"namespace", inverseExecPod.Namespace, "command", inverseExecPod.Command)
+}
+
+func shouldInverseOpBeExecuted(inverseOp string, hookSpec *kubeobjects.HookSpec, err error) bool {
+	// TODO: shouldOpHookBeFailedOnError to be used?
+	return err != nil && inverseOp != "" && shouldOpHookBeFailedOnError(hookSpec)
+}
+
+func (e ExecHook) getHookSpecForInverseOp(inverseOp string) *kubeobjects.HookSpec {
+	invHookParts := make([]string, 0)
+	if strings.Contains(inverseOp, "/") {
+		invHookParts = strings.Split(inverseOp, "/")
+	} else {
+		invHookParts = append(invHookParts, e.Hook.Name)
+		invHookParts = append(invHookParts, inverseOp)
+	}
+
+	hooks := e.RecipeElements.RecipeWithParams.Spec.Hooks
+
+	hook := getMatchingHook(hooks, invHookParts[0])
+	if hook != nil {
+		return getHookSpec(hook, invHookParts[1])
+	}
+
+	return nil
+}
+
+func getHookSpec(hook *recipev1.Hook, inverseOp string) *kubeobjects.HookSpec {
+	for _, op := range hook.Ops {
+		if op.Name == inverseOp {
+			return &kubeobjects.HookSpec{
+				Name: hook.Name,
+				Op: kubeobjects.Operation{
+					Name:      op.Name,
+					Command:   op.Command,
+					Container: op.Container,
+					InverseOp: op.InverseOp,
+					Timeout:   op.Timeout,
+					OnError:   op.OnError,
+				},
+				SelectResource: hook.SelectResource,
+				LabelSelector:  hook.LabelSelector,
+				NameSelector:   hook.NameSelector,
+				Namespace:      hook.Namespace,
+				SinglePodOnly:  hook.SinglePodOnly,
+				Timeout:        hook.Timeout,
+				Essential:      hook.Essential,
+				OnError:        hook.OnError,
+			}
 		}
 	}
 
 	return nil
+}
+
+func getMatchingHook(hooks []*recipev1.Hook, hookName string) *recipev1.Hook {
+	for _, hook := range hooks {
+		if hook.Name == hookName && hook.Type == "exec" {
+			return hook
+		}
+	}
+
+	return nil
+}
+
+func (e ExecHook) executeCommands(execPods []ExecPodSpec, log logr.Logger) (ExecPodSpec, error) {
+	for _, execPod := range execPods {
+		err := executeCommand(&execPod, e.Hook, e.Scheme, log)
+		if err != nil && getOpHookOnError(e.Hook) == defaultOnErrorValue {
+			log.Error(err, "error executing command on pod", "pod", execPod.PodName,
+				"namespace", execPod.Namespace, "command", execPod.Command)
+
+			return execPod, fmt.Errorf("error executing exec hook: %w", err)
+		}
+	}
+
+	return ExecPodSpec{}, nil
 }
 
 func executeCommand(execPod *ExecPodSpec, hook *kubeobjects.HookSpec, scheme *runtime.Scheme, log logr.Logger) error {
@@ -558,4 +671,17 @@ func covertCommandToStringArray(command string) ([]string, error) {
 	}
 
 	return cmd, nil
+}
+
+func shouldOpHookBeFailedOnError(hook *kubeobjects.HookSpec) bool {
+	// hook.Check.OnError overwrites the feature of hook.OnError -- defaults to fail
+	if hook.Op.OnError != "" && hook.Op.OnError == "continue" {
+		return false
+	}
+
+	if hook.OnError != "" && hook.OnError == "continue" {
+		return false
+	}
+
+	return true
 }

--- a/internal/controller/hooks/hooks_factory.go
+++ b/internal/controller/hooks/hooks_factory.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+	"github.com/ramendr/ramen/internal/controller/util"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -20,12 +21,14 @@ type HookExecutor interface {
 }
 
 // Based on the hook type, return the appropriate implementation of the hook.
-func GetHookExecutor(hook kubeobjects.HookSpec, reader client.Reader, scheme *runtime.Scheme) (HookExecutor, error) {
+func GetHookExecutor(hook kubeobjects.HookSpec, reader client.Reader, scheme *runtime.Scheme,
+	recipeElements util.RecipeElements,
+) (HookExecutor, error) {
 	switch hook.Type {
 	case "check":
 		return CheckHook{Hook: &hook, Reader: reader}, nil
 	case "exec":
-		return ExecHook{Hook: &hook, Reader: reader, Scheme: scheme}, nil
+		return ExecHook{Hook: &hook, Reader: reader, Scheme: scheme, RecipeElements: recipeElements}, nil
 	default:
 		return nil, fmt.Errorf("unsupported hook type")
 	}

--- a/internal/controller/hooks/hooks_factory_test.go
+++ b/internal/controller/hooks/hooks_factory_test.go
@@ -7,25 +7,29 @@ import (
 
 	"github.com/ramendr/ramen/internal/controller/hooks"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+	"github.com/ramendr/ramen/internal/controller/util"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetHookExecutor(t *testing.T) {
 	client := fake.NewFakeClient()
 
-	executor, err := hooks.GetHookExecutor(getHookSpecForFactoryTest("check"), client, client.Scheme())
+	executor, err := hooks.GetHookExecutor(getHookSpecForFactoryTest("check"), client, client.Scheme(),
+		util.RecipeElements{})
 	assert.Nil(t, err)
 
 	_, ok := executor.(hooks.CheckHook)
 	assert.True(t, ok)
 
-	executor, err = hooks.GetHookExecutor(getHookSpecForFactoryTest("exec"), client, client.Scheme())
+	executor, err = hooks.GetHookExecutor(getHookSpecForFactoryTest("exec"), client, client.Scheme(),
+		util.RecipeElements{})
 	assert.Nil(t, err)
 
 	_, ok = executor.(hooks.ExecHook)
 	assert.True(t, ok)
 
-	executor, err = hooks.GetHookExecutor(getHookSpecForFactoryTest("undefined"), client, client.Scheme())
+	executor, err = hooks.GetHookExecutor(getHookSpecForFactoryTest("undefined"), client, client.Scheme(),
+		util.RecipeElements{})
 
 	assert.Nil(t, executor)
 	assert.EqualError(t, err, "unsupported hook type")

--- a/internal/controller/util/recipe.go
+++ b/internal/controller/util/recipe.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+	recipev1 "github.com/ramendr/recipe/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type RecipeElements struct {
+	PvcSelector      PvcSelector
+	CaptureWorkflow  []kubeobjects.CaptureSpec
+	RecoverWorkflow  []kubeobjects.RecoverSpec
+	CaptureFailOn    string
+	RestoreFailOn    string
+	RecipeWithParams *recipev1.Recipe
+}
+
+type PvcSelector struct {
+	LabelSelector  metav1.LabelSelector
+	NamespaceNames []string
+}

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -489,7 +489,7 @@ type VRGInstance struct {
 	instance             *ramendrv1alpha1.VolumeReplicationGroup
 	savedInstanceStatus  ramendrv1alpha1.VolumeReplicationGroupStatus
 	ramenConfig          *ramendrv1alpha1.RamenConfig
-	recipeElements       RecipeElements
+	recipeElements       util.RecipeElements
 	volRepPVCs           []corev1.PersistentVolumeClaim
 	volSyncPVCs          []corev1.PersistentVolumeClaim
 	replClassList        *volrep.VolumeReplicationClassList

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -292,7 +292,8 @@ func (v *VRGInstance) executeCaptureSteps(result *ctrl.Result, pathName, capture
 		if cg.IsHook {
 			isEssentialStep = cg.Hook.Essential != nil && *cg.Hook.Essential
 
-			executor, err1 := hooks.GetHookExecutor(cg.Hook, v.reconciler.APIReader, v.reconciler.Scheme)
+			executor, err1 := hooks.GetHookExecutor(cg.Hook, v.reconciler.APIReader, v.reconciler.Scheme,
+				v.recipeElements)
 			if err1 != nil {
 				// continue if hook type is not supported. Supported types are "check" and "exec"
 				log1.Info("Hook type not supported", "hook", cg.Hook)
@@ -756,7 +757,8 @@ func (v *VRGInstance) executeRecoverSteps(result *ctrl.Result, s3StoreAccessor s
 		if rg.IsHook {
 			isEssentialStep = rg.Hook.Essential != nil && *rg.Hook.Essential
 
-			executor, err1 := hooks.GetHookExecutor(rg.Hook, v.reconciler.APIReader, v.reconciler.Scheme)
+			executor, err1 := hooks.GetHookExecutor(rg.Hook, v.reconciler.APIReader, v.reconciler.Scheme,
+				v.recipeElements)
 			if err1 != nil {
 				// continue if hook type is not supported. Supported types are "check" and "exec"
 				log1.Info("Hook type not supported", "hook", rg.Hook)

--- a/internal/controller/vrg_recipe_test.go
+++ b/internal/controller/vrg_recipe_test.go
@@ -13,6 +13,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	ramen "github.com/ramendr/ramen/api/v1alpha1"
 	controllers "github.com/ramendr/ramen/internal/controller"
+	"github.com/ramendr/ramen/internal/controller/util"
 	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -299,7 +300,7 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 	vrgPvcsConsistOfEventually := func(pvcs ...*corev1.PersistentVolumeClaim) {
 		Eventually(vrgPvcsGet, timeout, interval).Should(ConsistOf(vrgPvcNamesMatchPvcs(pvcs...)))
 	}
-	vrgPvcSelectorGet := func() (controllers.PvcSelector, error) {
+	vrgPvcSelectorGet := func() (util.PvcSelector, error) {
 		return controllers.GetPVCSelector(ctx, apiReader, *vrg, *ramenConfig, testLogger)
 	}
 	skipIfAdmissionValidateAndCommitAreAtomicIs := func(condition bool, message string) {
@@ -421,7 +422,7 @@ var _ = Describe("VolumeReplicationGroupRecipe", func() {
 			BeforeEach(OncePerOrdered, func() {
 				vrgRecipeRefDefine(r.Name)
 			})
-			var pvcSelector controllers.PvcSelector
+			var pvcSelector util.PvcSelector
 			var err error
 			JustBeforeEach(func() {
 				pvcSelector, err = vrgPvcSelectorGet()


### PR DESCRIPTION
Adding implementation for inverse operation if provided for the exec hook. The changes include:
1. Move RecipeElements to util so that it can be re-used without import cycle and update all the references.
2. If the exec hook fails and inverseOp is specified, get the matching captureSpec or recoverSpec from the recipeElements and execute the hook.
3. If the inverseOp matching recoverSpec or captureSpec is not found, then return error.
4. In case captureSpec or recoverSpec is found, create a temp ExecHook and then call the functions which obtains all the relevant pods and then execute the commands.

Modified the implementation to:
1. Send the recipe expanded version embedded in RecipeElements,
2. When executing inverseOp, refer to the recipe and get the hook spec needed for hook execution.
3. Execute inverseOp hook.


(cherry picked from commit 16c2270e6491f1cb36d430927bb1459fd2c2c5bf)