### PR TITLE
DFBUGS-2106: Backport of upstream PR 2051

### DIFF
--- a/internal/controller/hooks/exec_hook.go
+++ b/internal/controller/hooks/exec_hook.go
@@ -96,7 +96,6 @@ func (e ExecHook) executeInverseOp(inverseOp string, log logr.Logger) {
 }
 
 func shouldInverseOpBeExecuted(inverseOp string, hookSpec *kubeobjects.HookSpec, err error) bool {
-	// TODO: shouldOpHookBeFailedOnError to be used?
 	return err != nil && inverseOp != "" && shouldOpHookBeFailedOnError(hookSpec)
 }
 

--- a/internal/controller/util/recipe.go
+++ b/internal/controller/util/recipe.go
@@ -10,12 +10,17 @@ import (
 )
 
 type RecipeElements struct {
-	PvcSelector      PvcSelector
-	CaptureWorkflow  []kubeobjects.CaptureSpec
-	RecoverWorkflow  []kubeobjects.RecoverSpec
-	CaptureFailOn    string
-	RestoreFailOn    string
-	RecipeWithParams *recipev1.Recipe
+	PvcSelector         PvcSelector
+	CaptureWorkflow     []kubeobjects.CaptureSpec
+	RecoverWorkflow     []kubeobjects.RecoverSpec
+	CaptureFailOn       string
+	RestoreFailOn       string
+	RecipeWithParams    *recipev1.Recipe
+	StopRecipeReconcile bool
+}
+
+type RecipeStatus struct {
+	Attempts int
 }
 
 type PvcSelector struct {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -57,6 +57,7 @@ type VolumeReplicationGroupReconciler struct {
 	kubeObjects         kubeobjects.RequestsManager
 	RateLimiter         *workqueue.TypedRateLimiter[reconcile.Request]
 	veleroCRsAreWatched bool
+	recipeStatus        map[string]*util.RecipeStatus
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -26,6 +26,8 @@ import (
 
 var ErrWorkflowNotFound = fmt.Errorf("backup or restore workflow not found")
 
+const RecipeMaxAttempts = 10
+
 func kubeObjectsCaptureInterval(kubeObjectProtectionSpec *ramen.KubeObjectProtectionSpec) time.Duration {
 	if kubeObjectProtectionSpec.CaptureInterval == nil {
 		return ramen.KubeObjectProtectionCaptureIntervalDefault
@@ -229,9 +231,30 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResume(
 	annotations := map[string]string{vrgGenerationKey: strconv.FormatInt(generation, vrgGenerationNumberBase)}
 	labels := util.OwnerLabels(v.instance)
 
+	if v.recipeElements.StopRecipeReconcile {
+		v.kubeObjectsCaptureStatusFalse("KubeObjectsCaptureError",
+			"user stopped recipe reconciliation using recipe parameters")
+
+		return
+	}
+
 	allEssentialStepsFailed, err := v.executeCaptureSteps(result, pathName, capturePathName, namePrefix,
 		veleroNamespaceName, captureInProgressStatusUpdate, annotations, requests, log)
 	if err != nil {
+		recipeStatus := v.reconciler.recipeStatus[v.namespacedName]
+		if recipeStatus == nil {
+			recipeStatus = &util.RecipeStatus{}
+
+			v.reconciler.recipeStatus[v.namespacedName] = recipeStatus
+		}
+
+		recipeStatus.Attempts++
+		if recipeStatus.Attempts > RecipeMaxAttempts {
+			v.kubeObjectsCaptureStatusFalse("KubeObjectsCaptureError", "recipe reconcile failed for more that max attempts")
+
+			return
+		}
+
 		result.Requeue = true
 
 		return
@@ -489,6 +512,11 @@ func (v *VRGInstance) kubeObjectsCaptureIdentifierUpdateComplete(
 		result.Requeue = true
 
 		return
+	}
+
+	recipeStatus, ok := v.reconciler.recipeStatus[v.namespacedName]
+	if ok {
+		recipeStatus.Attempts = 0
 	}
 
 	v.kubeObjectsCaptureStatusTrue(VRGConditionReasonUploaded, kubeObjectsClusterDataProtectedTrueMessage)

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -406,8 +406,6 @@ func (v *VRGInstance) kubeObjectsGroupCapture(
 		} else {
 			err := request.Status(v.log)
 			if err == nil {
-				log1.Info("Kube objects group captured", "start", request.StartTime(), "end", request.EndTime())
-
 				requestsCompletedCount++
 
 				continue


### PR DESCRIPTION
The PR add the following:
1. Enable user to provide an option if he wants to stop the processing
   of recipe reconcilation. One can provide "STOP_RECIPE_RECONCILE" in
   the drpc recipeParameters as "true"/"false" to stop the execution. By
   default "false" will be considered.
2. Add max retries for processing a recipe. By default 10 max retries
   can be done. VRG reconcile will hold the memory of number of retries
   for each recipe.

Signed-off-by: Annaraya Narasagond <annarayanarasagond@gmail.com>
(cherry picked from commit e5e1f89)