### PR TITLE
DFBUGS-2592: Resolving panic issue

### DIFF
--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -336,8 +336,6 @@ func (v *VRGInstance) kubeObjectsGroupCapture(
 		} else {
 			err := request.Status(v.log)
 			if err == nil {
-				log1.Info("Kube objects group captured", "start", request.StartTime(), "end", request.EndTime())
-
 				requestsCompletedCount++
 
 				continue


### PR DESCRIPTION
In the lines above, status is already logged with nil checks. Hence, removing this log line.

The lines of implementation have changed between 4.18 and 4.19 onwards. Hence, could not cherry pick.