### PR TITLE
DFBUGS-2682: Fix for panic in kubeObjectsCaptureStartOrResume()

### DIFF
--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -125,6 +125,8 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 		r.Log.Info("Kube object protection disabled; don't watch kube objects requests")
 	}
 
+	r.recipeStatus = make(map[string]*util.RecipeStatus)
+
 	return ctrlBuilder.Complete(r)
 }
 


### PR DESCRIPTION
This fixes the panic in ramen-dr-cluster pod due to uninitialized map. [Panic in ramen-operator](https://github.com/RamenDR/ramen/issues/2069)


(cherry picked from commit 82c6b799496e06064fa8b225406e1055c92491c2)