### PR TITLE
DFBUGS-2652: Fix CephFS CG Enablement by also checking the CRD presence

### DIFF
--- a/internal/controller/replicationgroupsource_controller.go
+++ b/internal/controller/replicationgroupsource_controller.go
@@ -141,7 +141,7 @@ func (r *ReplicationGroupSourceReconciler) Reconcile(ctx context.Context, req ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReplicationGroupSourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	if util.IsCRDInstalled(context.TODO(), r.Client, util.VGSCRDName) {
+	if util.IsCRDInstalled(context.TODO(), r.APIReader, util.VGSCRDName) {
 		r.volumeGroupSnapshotCRsAreWatched = true
 	}
 

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -819,7 +819,7 @@ func (v *VSHandler) PreparePVC(pvcNamespacedName types.NamespacedName,
 		}
 	}
 
-	if prepFinalSync && !util.IsCGEnabled(v.owner.GetAnnotations()) {
+	if prepFinalSync && !util.IsCGEnabledForVolSync(v.ctx, v.client, v.owner.GetAnnotations()) {
 		err := v.prepareForFinalSync(pvcNamespacedName)
 		if err != nil {
 			return err

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -39,7 +39,7 @@ func (v *VRGInstance) restorePVsAndPVCsForVolSync() (int, error) {
 		rdSpec.ProtectedPVC.Conditions = nil
 
 		cgLabelVal, ok := rdSpec.ProtectedPVC.Labels[ConsistencyGroupLabel]
-		if ok && util.IsCGEnabled(v.instance.Annotations) {
+		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
 			v.log.Info("The CG label from the primary cluster found in RDSpec", "Label", cgLabelVal)
 			// Get the CG label value for this cluster
 			cgLabelVal, err = v.getCGLabelValue(rdSpec.ProtectedPVC.StorageClassName,
@@ -190,7 +190,7 @@ func (v *VRGInstance) reconcilePVCAsVolSyncPrimary(pvc corev1.PersistentVolumeCl
 	*finalSyncPrepared = true
 
 	cg, ok := pvc.Labels[ConsistencyGroupLabel]
-	if ok && util.IsCGEnabled(v.instance.Annotations) {
+	if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
 		v.log.Info("PVC has CG label", "Labels", pvc.Labels)
 		cephfsCGHandler := cephfscg.NewVSCGHandler(
 			v.ctx, v.reconciler.Client, v.instance,
@@ -355,7 +355,7 @@ func (v *VRGInstance) reconcileCGMembership() (map[string]struct{}, bool, error)
 
 	for _, rdSpec := range v.instance.Spec.VolSync.RDSpec {
 		cgLabelVal, ok := rdSpec.ProtectedPVC.Labels[ConsistencyGroupLabel]
-		if ok && util.IsCGEnabled(v.instance.Annotations) {
+		if ok && util.IsCGEnabledForVolSync(v.ctx, v.reconciler.APIReader, v.instance.Annotations) {
 			v.log.Info("RDSpec contains the CG label from the primary cluster", "Label", cgLabelVal)
 			// Get the CG label value for this cluster
 			cgLabelVal, err := v.getCGLabelValue(rdSpec.ProtectedPVC.StorageClassName,


### PR DESCRIPTION
This pull request updates the codebase to use the IsCGEnabledForVolSync function wherever we need to determine whether Consistency Group (CG) protection is enabled for CephFS workloads.

How it works:
The IsCGEnabledForVolSync function:

Checks whether the workload’s annotations for CG protection is enabled.
Checks whether the VolumeGroupSnapshot CRD is available in the cluster.
Only if both conditions are met is CG protection enabled for CephFS.

This update is a temporary solution until CG support becomes generally available for both RBD and CephFS. For now, it’s only applied to CephFS since CG for RBD is expected to be generally available in 4.19.

Fixes: https://issues.redhat.com/browse/DFBUGS-2652