### PR TITLE
DFBUGS-2574: velero: add metadata only label for kubevirt plugin

### DIFF
--- a/internal/controller/util/labels.go
+++ b/internal/controller/util/labels.go
@@ -12,11 +12,12 @@ const (
 	labelOwnerNamespaceName = "ramendr.openshift.io/owner-namespace-name"
 	labelOwnerName          = "ramendr.openshift.io/owner-name"
 
-	MModesLabel             = "ramendr.openshift.io/maintenancemodes"
-	SClassLabel             = "ramendr.openshift.io/storageclass"
-	VSClassLabel            = "ramendr.openshift.io/volumesnapshotclass"
-	VRClassLabel            = "ramendr.openshift.io/volumereplicationclass"
-	ExcludeFromVeleroBackup = "velero.io/exclude-from-backup"
+	MModesLabel                           = "ramendr.openshift.io/maintenancemodes"
+	SClassLabel                           = "ramendr.openshift.io/storageclass"
+	VSClassLabel                          = "ramendr.openshift.io/volumesnapshotclass"
+	VRClassLabel                          = "ramendr.openshift.io/volumereplicationclass"
+	ExcludeFromVeleroBackup               = "velero.io/exclude-from-backup"
+	VeleroKubevirtMetadataOnlyBackupLabel = "velero.kubevirt.io/metadataBackup"
 )
 
 type Labels map[string]string

--- a/internal/controller/util/recipe.go
+++ b/internal/controller/util/recipe.go
@@ -19,10 +19,6 @@ type RecipeElements struct {
 	StopRecipeReconcile bool
 }
 
-type RecipeStatus struct {
-	Attempts int
-}
-
 type PvcSelector struct {
 	LabelSelector  metav1.LabelSelector
 	NamespaceNames []string

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -57,7 +58,7 @@ type VolumeReplicationGroupReconciler struct {
 	kubeObjects         kubeobjects.RequestsManager
 	RateLimiter         *workqueue.TypedRateLimiter[reconcile.Request]
 	veleroCRsAreWatched bool
-	recipeStatus        map[string]*util.RecipeStatus
+	recipeRetries       sync.Map
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -124,8 +125,6 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 	} else {
 		r.Log.Info("Kube object protection disabled; don't watch kube objects requests")
 	}
-
-	r.recipeStatus = make(map[string]*util.RecipeStatus)
 
 	return ctrlBuilder.Complete(r)
 }

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -241,15 +241,19 @@ func (v *VRGInstance) kubeObjectsCaptureStartOrResume(
 	allEssentialStepsFailed, err := v.executeCaptureSteps(result, pathName, capturePathName, namePrefix,
 		veleroNamespaceName, captureInProgressStatusUpdate, annotations, requests, log)
 	if err != nil {
-		recipeStatus := v.reconciler.recipeStatus[v.namespacedName]
-		if recipeStatus == nil {
-			recipeStatus = &util.RecipeStatus{}
-
-			v.reconciler.recipeStatus[v.namespacedName] = recipeStatus
+		rStatus, ok := v.reconciler.recipeRetries.Load(v.namespacedName)
+		if !ok {
+			v.reconciler.recipeRetries.Store(v.namespacedName, 0)
 		}
 
-		recipeStatus.Attempts++
-		if recipeStatus.Attempts > RecipeMaxAttempts {
+		val, ok := rStatus.(int)
+		if ok {
+			val++
+		}
+
+		v.reconciler.recipeRetries.Store(v.namespacedName, val)
+
+		if val > RecipeMaxAttempts {
 			v.kubeObjectsCaptureStatusFalse("KubeObjectsCaptureError", "recipe reconcile failed for more that max attempts")
 
 			return
@@ -513,11 +517,7 @@ func (v *VRGInstance) kubeObjectsCaptureIdentifierUpdateComplete(
 		return
 	}
 
-	recipeStatus, ok := v.reconciler.recipeStatus[v.namespacedName]
-	if ok {
-		recipeStatus.Attempts = 0
-	}
-
+	v.reconciler.recipeRetries.Store(v.namespacedName, 0)
 	v.kubeObjectsCaptureStatusTrue(VRGConditionReasonUploaded, kubeObjectsClusterDataProtectedTrueMessage)
 
 	captureStartTimeSince := time.Since(captureToRecoverFromIdentifier.StartTime.Time)

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -301,6 +301,7 @@ func (v *VRGInstance) executeCaptureSteps(result *ctrl.Result, pathName, capture
 	requestsProcessedCount := 0
 	requestsCompletedCount := 0
 	labels := util.OwnerLabels(v.instance)
+	labels[util.VeleroKubevirtMetadataOnlyBackupLabel] = "true"
 
 	for groupNumber, captureGroup := range captureSteps {
 		var err error


### PR DESCRIPTION
Adding velero.kubevirt.io/metadataBackup label to the backup request
ensures that kubevirt velero plugin skips the restore check and
consistency-specific checks when a backup is taken. This is required as
we backup the pvc/pv ourselves in Ramen and skip them from the velero
backup; otherwise the checks fail.

Co-Authored-by: Annaraya Narasagond <annarayanarasagond@gmail.com>
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>
(cherry picked from commit 34143d9)