### PR TITLE
change severity level of WorkloadUnprotected alert

### DIFF
--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -36,7 +36,7 @@ spec:
           expr: ramen_workload_protection_status == 0
           for: 10m
           labels:
-            severity: warning
+            severity: critical
           annotations:
             description: "Workload is not protected for disaster recovery (DRPC: {{ $labels.obj_name }}, Namespace: {{ $labels.obj_namespace }})."
             alert_type: "DisasterRecovery"


### PR DESCRIPTION
change the severity level from warning to critical so that the alert is not ignored by user since
warning alerts are ignored most of the time.


(cherry picked from commit 696427a1c5d97c871ddc9a0311f0356fa809917d)