### PR TITLE
DFBUGS-3847: Ensure the VGR resource name ends with an alphanumeric character

### DIFF
--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"reflect"
+	"strings"
 
 	"github.com/google/uuid"
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -386,7 +387,7 @@ func IsPVCMarkedForVolSync(annotations map[string]string) bool {
 func TrimToK8sResourceNameLength(name string) string {
 	const maxLength = 63
 	if len(name) > maxLength {
-		return name[:maxLength]
+		return strings.TrimRight(name[:maxLength], "-.")
 	}
 
 	return name

--- a/internal/controller/util/misc_test.go
+++ b/internal/controller/util/misc_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/ramendr/ramen/internal/controller/util"
+	"k8s.io/apimachinery/pkg/api/validation"
 )
 
 var _ = Describe("misc", func() {
@@ -35,4 +36,11 @@ var _ = Describe("misc", func() {
 
 	Expect(util.GenerateCombinedName(pvcNamespace5, storageID2)).
 		Should(Equal("ce2e9aed-5b7c8892"))
+
+	longResourceName := "54a5f0ff705e7f7d94338c65839890abapp-busybox-rbd-1-cg-placement---------------..--"
+
+	validResourceName := util.TrimToK8sResourceNameLength(longResourceName)
+	errs := validation.NameIsDNSSubdomain(validResourceName, false)
+
+	Expect(errs).To(BeEmpty(), "expected a valid DNS subdomain name, got errors: %v", errs)
 })


### PR DESCRIPTION
During VolumeGroupReplication resource name creation, the CG label from the PVC is concatenated with the VRG name and trimmed to the maximum Kubernetes resource name length (63 characters).

If the resulting name ends with a non-alphanumeric character, the VGR resource creation fails with the following error:

Invalid value: "54a5f0ff705e7f7d94338c65839890abapp-busybox-rbd-1-cg-placement-": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')

This PR adds validation, that future VGR resource name ends with an alphanumeric character.

Fixes: https://issues.redhat.com/browse/DFBUGS-3847

(cherry picked from commit 9f9340ba03e98d1efca6d1f0d53e714b59b3e42d)