### PR TITLE
drenv: Fix fragile test

### DIFF
--- a/test/drenv/kubectl_test.py
+++ b/test/drenv/kubectl_test.py
@@ -127,7 +127,7 @@ def test_delete(tmpenv, capsys):
     kubectl.delete(pod, context=tmpenv.profile)
     out, err = capsys.readouterr()
     _, name = pod.split("/", 1)
-    assert out.strip() == f'pod "{name}" deleted'
+    assert out.strip().startswith(f'pod "{name}" deleted')
 
 
 def test_watch(tmpenv):


### PR DESCRIPTION
kubectl 1.34.0 changes the delete message, breaking our test:

    >       assert out.strip() == f'pod "{name}" deleted'
    E       assert 'pod "example...ult namespace' == 'pod "example...x5hw" deleted'
    E
    E         - pod "example-deployment-68b69d9d56-vx5hw" deleted
    E         + pod "example-deployment-68b69d9d56-vx5hw" deleted from default namespace
    E         ?                                                  +++++++++++++++++++++++

Change the assert to check for the start of the string so it can work with both old an new kubectl versions.


(cherry picked from commit e80201b7cc7ffa2b30b6d472c3bc1742573e2430)