### PR TITLE
DFBUGS-3853: correcting check hook error message

### DIFF
--- a/internal/controller/hooks/check_hook.go
+++ b/internal/controller/hooks/check_hook.go
@@ -111,7 +111,8 @@ func EvaluateCheckHookForObjects(objs []client.Object, hook *kubeobjects.HookSpe
 		if err != nil {
 			log.Info("error executing check hook", "for", hook.Name, "with error", err)
 
-			return false, err
+			return false, fmt.Errorf("error executing check hook %s/%s in namespace %s with selectResource %s: %w",
+				hook.Name, hook.Chk.Name, hook.Namespace, hook.SelectResource, err)
 		}
 
 		log.Info("check hook executed for", "hook", hook.Name, "resource type", hook.SelectResource, "with object name",

--- a/internal/controller/hooks/json_util.go
+++ b/internal/controller/hooks/json_util.go
@@ -76,6 +76,10 @@ func evaluateBooleanExpression(expression string, jsonData interface{}) (bool, e
 		}
 	}
 
+	if operands[0].Kind() == reflect.Invalid || operands[1].Kind() == reflect.Invalid {
+		return false, fmt.Errorf("either resource is not found or status is not initialized")
+	}
+
 	return compare(operands[0], operands[1], op)
 }
 


### PR DESCRIPTION
Earlier, to add/update the log for check hook when resource is not found or status not initialised, hookSpec was passed on all through to util function which is more that required information. Reverted some portion of the code and now in the caller updating the required info to the returned error message.


(cherry picked from commit 2bd52a7cc3735895b2e5bd80a7fe38a8bccfab5c)