### PR TITLE
DFBUGS-2889: Fix for volsync labels

### DIFF
--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -695,6 +695,7 @@ func (v *VSHandler) createTmpPVCForFinalSync(pvcNamespacedName types.NamespacedN
 		tmpPVC.ObjectMeta.Labels = map[string]string{} // don't include it in the next reconciliation
 		tmpPVC.Finalizers = nil
 		tmpPVC.Annotations = map[string]string{} // {"ramendr/tmp-pvc-created": "yes"}
+		util.AddLabel(tmpPVC, util.CreatedByRamenLabel, "true")
 	} else {
 		v.log.V(1).Info("Found tmp PVC", "tmpPVC", tmpPVC.Name)
 
@@ -1435,8 +1436,6 @@ func (v *VSHandler) EnsurePVCforDirectCopy(ctx context.Context,
 			Namespace: rdSpec.ProtectedPVC.Namespace,
 		},
 	}
-
-	util.AddLabel(pvc, util.CreatedByRamenLabel, "true")
 
 	op, err := ctrlutil.CreateOrUpdate(ctx, v.client, pvc, func() error {
 		if !v.vrgInAdminNamespace {


### PR DESCRIPTION
With discovered apps + CephFS using recipe for selecting the PVCs that are not excluded in the recipe. When volsync is in use, during failover/relocate before finalsync a temporary PVC is created but is not labelled as created by ramen due to which temp PVC was getting protected, thus halting the clean up in former primary.


(cherry picked from commit 34227cc779a9aef2f3411b7021263e7e2067315b)