### PR TITLE
DFBUGS-4064: Fix for PVC size request(spec) v/s allocated(status) compare error.

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -620,7 +620,10 @@ func (v *VRGInstance) isArchivedAlready(pvc *corev1.PersistentVolumeClaim, log l
 }
 
 func (v *VRGInstance) isPVCResizeCompleted(pvc *corev1.PersistentVolumeClaim) bool {
-	return pvc.Spec.Resources.Requests["storage"] == pvc.Status.Capacity["storage"]
+	requested := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+	actual := pvc.Status.Capacity[corev1.ResourceStorage]
+
+	return requested.Cmp(actual) == 0
 }
 
 // Upload PV to the list of S3 stores in the VRG spec


### PR DESCRIPTION
(cherry picked from commit c3887724b66d0381dfdd3b27ab9739ae8770d5e5)

The error occurs due to a format mismatch when comparing the PVC's requested storage size (spec.resources.requests["storage"]) with its actual allocated size (status.capacity["storage"]). Although both values represent the same amount of storage (e.g., 30Gi), they are expressed in different formats:
spec may use a raw byte string like "32212254720"
status may use a human-readable format like "30Gi"
When the operator controller performs a direct equality check (==) between these two resource.Quantity objects, the comparison fails because it checks the string representation, not the numeric value. This leads the controller to incorrectly assume that a resize is in progress, causing:
Immediate requeue of the reconciliation loop
Skipping of subsequent processing steps (e.g., uploading PVC metadata to S3)
