### PR TITLE
DFBUGS-3804: Ensure "do-not-delete-pvc" annotation propagates before allowing VRG deletion

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -772,6 +772,10 @@ func (r *DRPlacementControlReconciler) ensureVRGsDeleted(
 				return fmt.Errorf("%s VRG adoption in progress", replicationState)
 			}
 
+			if err := r.ensureDoNotDeletePVCAnnotation(mwu, drpc, vrg, cluster, r.Log); err != nil {
+				return fmt.Errorf("wait for annotation to propagate to the VRG. Error: %w", err)
+			}
+
 			if err := mwu.DeleteManifestWork(mwu.BuildManifestWorkName(rmnutil.MWTypeVRG), cluster); err != nil {
 				return fmt.Errorf("failed to delete %s VRG manifestwork for cluster %q: %w", replicationState, cluster, err)
 			}
@@ -2885,4 +2889,77 @@ func (r *DRPlacementControlReconciler) twoVMDRPCsConflict(drpc *rmn.DRPlacementC
 	}
 
 	return false
+}
+
+// ensureDoNotDeletePVCAnnotation ensures that the "do-not-delete-pvc" annotation is propagated from the DRPC
+// resource to the VRG resource on the specified cluster. If the annotation is set on the DRPC but not yet
+// present on the VRG, this function updates the VRG ManifestWork to include the annotation. This is used to
+// prevent deletion of app PVCs during DR disabling.
+func (r *DRPlacementControlReconciler) ensureDoNotDeletePVCAnnotation(
+	mwu rmnutil.MWUtil,
+	drpc *rmn.DRPlacementControl,
+	vrg *rmn.VolumeReplicationGroup,
+	cluster string,
+	log logr.Logger,
+) error {
+	if vrg.Spec.ReplicationState != rmn.Primary {
+		return nil // Only propagate the annotation if the VRG is in primary state
+	}
+
+	if drpc.GetAnnotations()[DoNotDeletePVCAnnotation] == DoNotDeletePVCAnnotationVal &&
+		vrg.GetAnnotations()[DoNotDeletePVCAnnotation] != DoNotDeletePVCAnnotationVal {
+		return propagateAnnotationToVRG(mwu, cluster, DoNotDeletePVCAnnotation, DoNotDeletePVCAnnotationVal, log)
+	}
+
+	return nil
+}
+
+// propagateAnnotationToVRG adds or updates a specific annotation on a VRG resource in the ManifestWork
+// for the given cluster. This is typically used to propagate the "do-not-delete-pvc" annotation from
+// the DRPC to the VRG, to ensure that app PVCs are not deleted during DR disabling.
+func propagateAnnotationToVRG(
+	mwu rmnutil.MWUtil,
+	toCluster string,
+	annoKey, annoValue string,
+	log logr.Logger,
+) error {
+	log.Info("propagate Annotation to VRG")
+
+	mw, mwErr := mwu.FindManifestWorkByType(rmnutil.MWTypeVRG, toCluster)
+	if mwErr != nil {
+		if k8serrors.IsNotFound(mwErr) {
+			return fmt.Errorf("failed to find ManifestWork for VRG and cluster %s", toCluster)
+		}
+
+		return fmt.Errorf("error (%w) in finding ManifestWork for VRG and cluster %s",
+			mwErr, toCluster)
+	}
+
+	vrg, err := rmnutil.ExtractVRGFromManifestWork(mw)
+	if err != nil {
+		return fmt.Errorf("error extracting VRG from ManifestWork for cluster %s. Error: %w", toCluster, err)
+	}
+
+	if vrg.Spec.ReplicationState != rmn.Primary {
+		return fmt.Errorf("invalid update for VRG in %s spec.replicationState on cluster %s",
+			vrg.Spec.ReplicationState, toCluster)
+	}
+
+	if vrg.GetAnnotations() == nil {
+		vrg.SetAnnotations(make(map[string]string))
+	}
+
+	if vrg.GetAnnotations()[annoKey] == annoValue {
+		log.Info(fmt.Sprintf("Annotation %s already exists with value %s on VRG %s in cluster %s",
+			annoKey, annoValue, vrg.Name, toCluster))
+
+		return nil
+	}
+
+	log.Info(fmt.Sprintf("Adding/Updating Annotation %s with value %s on VRG %s in cluster %s",
+		annoKey, annoValue, vrg.Name, toCluster))
+
+	vrg.GetAnnotations()[annoKey] = annoValue
+
+	return mwu.UpdateVRGManifestWork(vrg, mw)
 }

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -773,7 +773,7 @@ func (r *DRPlacementControlReconciler) ensureVRGsDeleted(
 			}
 
 			if err := r.ensureDoNotDeletePVCAnnotation(mwu, drpc, vrg, cluster, r.Log); err != nil {
-				return fmt.Errorf("wait for annotation to propagate to the VRG. Error: %w", err)
+				return fmt.Errorf("wait for annotation to propagate to the VRG. Msg: %w", err)
 			}
 
 			if err := mwu.DeleteManifestWork(mwu.BuildManifestWorkName(rmnutil.MWTypeVRG), cluster); err != nil {
@@ -2908,7 +2908,9 @@ func (r *DRPlacementControlReconciler) ensureDoNotDeletePVCAnnotation(
 
 	if drpc.GetAnnotations()[DoNotDeletePVCAnnotation] == DoNotDeletePVCAnnotationVal &&
 		vrg.GetAnnotations()[DoNotDeletePVCAnnotation] != DoNotDeletePVCAnnotationVal {
-		return propagateAnnotationToVRG(mwu, cluster, DoNotDeletePVCAnnotation, DoNotDeletePVCAnnotationVal, log)
+		err := propagateAnnotationToVRG(mwu, cluster, DoNotDeletePVCAnnotation, DoNotDeletePVCAnnotationVal, log)
+
+		return fmt.Errorf("annotation hasn't been propagated to cluster %s (%w)", cluster, err)
 	}
 
 	return nil


### PR DESCRIPTION
When disabling DR, the UI adds the do-not-delete-pvc annotation and then deletes the DRPC in a second step. However, by the time Ramen reconciles the DRPC resource, it may already be in a deleted state. In that case, the annotation wouldn’t propagate to the VRG, which could result in unintended deletion of application PVCs.

This change updates the DRPC controller to verify that the annotation is present on both the DRPC and the VRG before permitting VRG deletion. This ensures the annotation is properly propagated and prevents accidental PVC removal.

Fixes: https://issues.redhat.com/browse/DFBUGS-3804