### PR TITLE
DFBUGS-3860: Fix race condition in ReplicationSource manual sync checks

### DIFF
--- a/hack/fakes/fake_volume_group_source_handler.go
+++ b/hack/fakes/fake_volume_group_source_handler.go
@@ -36,7 +36,7 @@ type FakeVolumeGroupSourceHandler struct {
 	cleanVolumeGroupSnapshotReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CreateOrUpdateReplicationSourceForRestoredPVCsStub        func(context.Context, string, []cephfscg.RestoredPVC, v1a.Object) ([]*v1.ObjectReference, error)
+	CreateOrUpdateReplicationSourceForRestoredPVCsStub        func(context.Context, string, []cephfscg.RestoredPVC, v1a.Object) ([]*v1.ObjectReference, bool, error)
 	createOrUpdateReplicationSourceForRestoredPVCsMutex       sync.RWMutex
 	createOrUpdateReplicationSourceForRestoredPVCsArgsForCall []struct {
 		arg1 context.Context
@@ -52,7 +52,7 @@ type FakeVolumeGroupSourceHandler struct {
 		result1 []*v1.ObjectReference
 		result2 error
 	}
-	CreateOrUpdateVolumeGroupSnapshotStub        func(context.Context, v1a.Object) error
+	CreateOrUpdateVolumeGroupSnapshotStub        func(context.Context, v1a.Object) (bool, error)
 	createOrUpdateVolumeGroupSnapshotMutex       sync.RWMutex
 	createOrUpdateVolumeGroupSnapshotArgsForCall []struct {
 		arg1 context.Context
@@ -213,7 +213,7 @@ func (fake *FakeVolumeGroupSourceHandler) CleanVolumeGroupSnapshotReturnsOnCall(
 	}{result1}
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCs(arg1 context.Context, arg2 string, arg3 []cephfscg.RestoredPVC, arg4 v1a.Object) ([]*v1.ObjectReference, error) {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCs(arg1 context.Context, arg2 string, arg3 []cephfscg.RestoredPVC, arg4 v1a.Object) ([]*v1.ObjectReference, bool, error) {
 	var arg3Copy []cephfscg.RestoredPVC
 	if arg3 != nil {
 		arg3Copy = make([]cephfscg.RestoredPVC, len(arg3))
@@ -235,9 +235,9 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRest
 		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, false, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, false, fakeReturns.result2
 }
 
 func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsCallCount() int {
@@ -246,7 +246,7 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRest
 	return len(fake.createOrUpdateReplicationSourceForRestoredPVCsArgsForCall)
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsCalls(stub func(context.Context, string, []cephfscg.RestoredPVC, v1a.Object) ([]*v1.ObjectReference, error)) {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVCsCalls(stub func(context.Context, string, []cephfscg.RestoredPVC, v1a.Object) ([]*v1.ObjectReference, bool, error)) {
 	fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.Lock()
 	defer fake.createOrUpdateReplicationSourceForRestoredPVCsMutex.Unlock()
 	fake.CreateOrUpdateReplicationSourceForRestoredPVCsStub = stub
@@ -285,7 +285,7 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRest
 	}{result1, result2}
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshot(arg1 context.Context, arg2 v1a.Object) error {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshot(arg1 context.Context, arg2 v1a.Object) (bool, error) {
 	fake.createOrUpdateVolumeGroupSnapshotMutex.Lock()
 	ret, specificReturn := fake.createOrUpdateVolumeGroupSnapshotReturnsOnCall[len(fake.createOrUpdateVolumeGroupSnapshotArgsForCall)]
 	fake.createOrUpdateVolumeGroupSnapshotArgsForCall = append(fake.createOrUpdateVolumeGroupSnapshotArgsForCall, struct {
@@ -300,9 +300,9 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshot(arg1
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1
+		return false, ret.result1
 	}
-	return fakeReturns.result1
+	return false, fakeReturns.result1
 }
 
 func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotCallCount() int {
@@ -311,7 +311,7 @@ func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotCallC
 	return len(fake.createOrUpdateVolumeGroupSnapshotArgsForCall)
 }
 
-func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotCalls(stub func(context.Context, v1a.Object) error) {
+func (fake *FakeVolumeGroupSourceHandler) CreateOrUpdateVolumeGroupSnapshotCalls(stub func(context.Context, v1a.Object) (bool, error)) {
 	fake.createOrUpdateVolumeGroupSnapshotMutex.Lock()
 	defer fake.createOrUpdateVolumeGroupSnapshotMutex.Unlock()
 	fake.CreateOrUpdateVolumeGroupSnapshotStub = stub

--- a/internal/controller/cephfscg/volumegroupsourcehandler_test.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Volumegroupsourcehandler", func() {
 	})
 	Describe("CreateOrUpdateVolumeGroupSnapshot", func() {
 		It("Should be successful", func() {
-			err := volumeGroupSourceHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+			_, err := volumeGroupSourceHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
 			Expect(err).To(BeNil())
 			Eventually(func() []string {
 				volumeGroupSnapshot := &vgsv1beta1.VolumeGroupSnapshot{}
@@ -88,7 +88,8 @@ var _ = Describe("Volumegroupsourcehandler", func() {
 		})
 		Context("Restored PVC exist", func() {
 			BeforeEach(func() {
-				err := volumeGroupSourceHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				createdOrUpdatedVGS, err := volumeGroupSourceHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				Expect(createdOrUpdatedVGS).To(BeTrue())
 				Expect(err).To(BeNil())
 				UpdateVGS(rgs, vsName, appPVCName)
 
@@ -121,7 +122,7 @@ var _ = Describe("Volumegroupsourcehandler", func() {
 		})
 		Context("There is VolumeGroupSnapshot, but not ready", func() {
 			BeforeEach(func() {
-				err := volumeGroupSourceHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
+				_, err := volumeGroupSourceHandler.CreateOrUpdateVolumeGroupSnapshot(context.TODO(), rgs)
 				Expect(err).To(BeNil())
 			})
 			It("Should be failed", func() {
@@ -145,10 +146,11 @@ var _ = Describe("Volumegroupsourcehandler", func() {
 
 	Describe("CreateOrUpdateReplicationSourceForRestoredPVCs", func() {
 		It("Should be successful", func() {
-			rsList, err := volumeGroupSourceHandler.CreateOrUpdateReplicationSourceForRestoredPVCs(
+			rsList, srcCreatedOrUpdated, err := volumeGroupSourceHandler.CreateOrUpdateReplicationSourceForRestoredPVCs(
 				context.Background(), "maunal",
 				[]cephfscg.RestoredPVC{{SourcePVCName: "source", RestoredPVCName: "resource", VolumeSnapshotName: "vs"}}, rgs)
 			Expect(err).To(BeNil())
+			Expect(srcCreatedOrUpdated).To(BeTrue())
 			Expect(len(rsList)).To(Equal(1))
 		})
 	})


### PR DESCRIPTION
When a ReplicationSource is created, the controller was immediately checking for sync completion. If the resource is created or updated but the cache is still stale, the check could incorrectly use the old sync completion state, causing the new manual trigger to be ignored. This case is not frequent.

The fix is to exit the reconciler upon creation or update of the ReplicationSource and VolumeGroupSnapshot.

(cherry picked from commit https://github.com/red-hat-storage/ramen/commit/eb0d64e10074d469986e99bc6b05d9c1b3cfdd44)