### PR TITLE
Check for PVC label selector conflicts and merge conflict conditions

### DIFF
--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1518,7 +1518,6 @@ func setConflictStatusCondition(existingConditions *[]metav1.Condition,
 	// TODO: Why not update lastTranTime if the above change?
 
 	if existingCondition.ObservedGeneration != newCondition.ObservedGeneration {
-		existingCondition.ObservedGeneration = newCondition.ObservedGeneration
 		existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
 	}
 

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -40,14 +40,16 @@ const (
 	// protected from a disaster by uploading it to the required S3 store(s).
 	VRGConditionTypeClusterDataProtected = "ClusterDataProtected"
 
-	VRGConditionTypeNoClusterDataConflict = "NoClusterDataConflict"
-
 	// VolSync related conditions. These conditions are only applicable
 	// at individual PVCs and not generic VRG conditions.
 	VRGConditionTypeVolSyncRepSourceSetup      = "ReplicationSourceSetup"
 	VRGConditionTypeVolSyncFinalSyncInProgress = "FinalSyncInProgress"
 	VRGConditionTypeVolSyncRepDestinationSetup = "ReplicationDestinationSetup"
 	VRGConditionTypeVolSyncPVsRestored         = "PVsRestored"
+
+	// Indicates no conflict in PVC and Kubernetes resource data
+	// between primary and secondary clusters.
+	VRGConditionTypeNoClusterDataConflict = "NoClusterDataConflict"
 )
 
 // VRG condition reasons
@@ -76,9 +78,14 @@ const (
 	VRGConditionReasonClusterDataAnnotationFailed = "AnnotationFailed"
 	VRGConditionReasonPeerClassNotFound           = "PeerClassNotFound"
 	VRGConditionReasonStorageIDNotFound           = "StorageIDNotFound"
-	VRGConditionReasonDataConflictPrimary         = "ClusterDataConflictPrimary"
-	VRGConditionReasonDataConflictSecondary       = "ClusterDataConflictSecondary"
-	VRGConditionReasonConflictResolved            = "ConflictResolved"
+	// Indicates a conflict in cluster data detected on the primary cluster.
+	VRGConditionReasonClusterDataConflictPrimary = "ClusterDataConflictPrimary"
+
+	// Indicates a conflict in cluster data detected on the secondary cluster.
+	VRGConditionReasonClusterDataConflictSecondary = "ClusterDataConflictSecondary"
+
+	// Indicates no conflict in cluster data detected on both the primary and secondary cluster.
+	VRGConditionReasonNoConflictDetected = "NoConflictDetected"
 )
 
 const (

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1989,9 +1989,10 @@ func (v *VRGInstance) updateVRGDataReadyCondition() {
 // The VRGConditionTypeClusterDataReady summary condition is not a PVC level
 // condition and is updated elsewhere.
 func (v *VRGInstance) updateVRGConditions() {
-	var volSyncDataProtected, volSyncClusterDataProtected *metav1.Condition
+	var volSyncDataProtected, volSyncClusterDataProtected, volSyncClusterDataConflict *metav1.Condition
 	if v.instance.Spec.Sync == nil {
 		volSyncDataProtected, volSyncClusterDataProtected = v.aggregateVolSyncDataProtectedConditions()
+		volSyncClusterDataConflict = v.aggregateVolSyncClusterDataConflictCondition()
 	}
 
 	v.updateVRGDataReadyCondition()
@@ -2006,6 +2007,7 @@ func (v *VRGInstance) updateVRGConditions() {
 		v.kubeObjectsProtected,
 	)
 	v.logAndSetConditions(VRGConditionTypeNoClusterDataConflict,
+		volSyncClusterDataConflict,
 		v.aggregateVRGNoClusterDataConflictCondition(),
 	)
 	v.updateVRGLastGroupSyncTime()
@@ -2112,8 +2114,8 @@ func isVRGReasonError(condition *metav1.Condition) bool {
 		condition.Reason == VRGConditionReasonErrorUnknown ||
 		condition.Reason == VRGConditionReasonUploadError ||
 		condition.Reason == VRGConditionReasonClusterDataAnnotationFailed ||
-		condition.Reason == VRGConditionReasonDataConflictPrimary ||
-		condition.Reason == VRGConditionReasonDataConflictSecondary
+		condition.Reason == VRGConditionReasonClusterDataConflictPrimary ||
+		condition.Reason == VRGConditionReasonClusterDataConflictSecondary
 }
 
 func (v *VRGInstance) s3StoreAccessorsGet() {
@@ -2345,6 +2347,10 @@ func (r *VolumeReplicationGroupReconciler) addKubeObjectsOwnsAndWatches(ctrlBuil
 }
 
 func (v *VRGInstance) validateVMsForStandaloneProtection() error {
+	if v.IsDRActionInProgress() {
+		return nil
+	}
+
 	if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary {
 		return v.CheckForVMConflictOnSecondary()
 	}
@@ -2354,6 +2360,24 @@ func (v *VRGInstance) validateVMsForStandaloneProtection() error {
 	}
 
 	return nil
+}
+
+func (v *VRGInstance) IsDRActionInProgress() bool {
+	spec := v.instance.Spec
+	status := v.instance.Status
+	isRepStateSecondary := spec.ReplicationState == ramendrv1alpha1.Secondary
+	switchedToSecondary := status.State == ramendrv1alpha1.SecondaryState
+
+	isRepStatePrimary := spec.ReplicationState == ramendrv1alpha1.Primary
+	switchedToPrimary := status.State == ramendrv1alpha1.PrimaryState
+
+	if (isRepStateSecondary && !switchedToSecondary) ||
+		(isRepStatePrimary && !switchedToPrimary) ||
+		v.instance.Generation != status.ObservedGeneration {
+		return true
+	}
+
+	return false
 }
 
 func (v *VRGInstance) CheckForVMConflictOnPrimary() error {
@@ -2435,6 +2459,59 @@ func (v *VRGInstance) CheckForVMNameConflictOnSecondary(vmNamespaceList, vmList 
 }
 
 func (v *VRGInstance) aggregateVRGNoClusterDataConflictCondition() *metav1.Condition {
+	var vmResourceConflict, pvcResourceConflict bool
+
+	vmResourceConflict = false
+	pvcResourceConflict = false
+
+	vmConflictCondition := v.aggregateVMNoClusterDataConflictCondition()
+	if vmConflictCondition != nil {
+		if vmConflictCondition.Status == metav1.ConditionFalse {
+			vmResourceConflict = true
+		}
+	}
+
+	pvcConflictCondition := v.aggregateVolRepClusterDataConflictCondition()
+	if pvcConflictCondition != nil {
+		if pvcConflictCondition.Status == metav1.ConditionFalse {
+			pvcResourceConflict = true
+		}
+	}
+
+	if !vmResourceConflict && !pvcResourceConflict {
+		return vmConflictCondition
+	}
+
+	// Priortize the resource conflict condition on Primary cluster
+	if vmResourceConflict && pvcResourceConflict {
+		return v.PriortizePrimaryClusterDataConflictCondition(vmConflictCondition, pvcConflictCondition)
+	}
+
+	if vmResourceConflict {
+		return vmConflictCondition
+	}
+
+	return pvcConflictCondition
+}
+
+func (v *VRGInstance) PriortizePrimaryClusterDataConflictCondition(
+	vmConflictCondition, pvcConflictCondition *metav1.Condition,
+) *metav1.Condition {
+	if vmConflictCondition.Reason == pvcConflictCondition.Reason {
+		vmConflictCondition.Message = fmt.Sprintf("Both VM and PVC resource conflicting on %s cluster",
+			v.instance.Spec.ReplicationState)
+
+		return vmConflictCondition
+	}
+
+	if vmConflictCondition.Reason == VRGConditionReasonClusterDataConflictPrimary {
+		return vmConflictCondition
+	}
+
+	return pvcConflictCondition
+}
+
+func (v *VRGInstance) aggregateVMNoClusterDataConflictCondition() *metav1.Condition {
 	var msg string
 
 	if v.isVMRecipeProtection() {
@@ -2456,11 +2533,11 @@ func (v *VRGInstance) aggregateVRGNoClusterDataConflictCondition() *metav1.Condi
 func (v *VRGInstance) clusterDataConflict(msg string, status metav1.ConditionStatus) *metav1.Condition {
 	if v.instance.Spec.ReplicationState == ramendrv1alpha1.Primary {
 		return updateVRGNoClusterDataConflictCondition(
-			v.instance.Generation, status, VRGConditionReasonDataConflictPrimary,
+			v.instance.Generation, status, VRGConditionReasonClusterDataConflictPrimary,
 			msg)
 	} else if v.instance.Spec.ReplicationState == ramendrv1alpha1.Secondary {
 		return updateVRGNoClusterDataConflictCondition(
-			v.instance.Generation, status, VRGConditionReasonDataConflictSecondary,
+			v.instance.Generation, status, VRGConditionReasonClusterDataConflictSecondary,
 			msg)
 	}
 
@@ -2475,4 +2552,50 @@ func (v *VRGInstance) isVMRecipeProtection() bool {
 	}
 
 	return false
+}
+
+func (v *VRGInstance) aggregateVolRepClusterDataConflictCondition() *metav1.Condition {
+	noClusterDataConflictCondition := &metav1.Condition{
+		Status:             metav1.ConditionTrue,
+		Type:               VRGConditionTypeNoClusterDataConflict,
+		Reason:             VRGConditionReasonNoConflictDetected,
+		ObservedGeneration: v.instance.Generation,
+		Message:            "No PVC conflict detected for VolumeReplication scheme",
+	}
+
+	if conflictCondition := v.validateSecondaryPVCConflictForVolRep(); conflictCondition != nil {
+		return conflictCondition
+	}
+
+	return noClusterDataConflictCondition
+}
+
+func (v *VRGInstance) IsSecondaryVRG() bool {
+	spec := v.instance.Spec
+	status := v.instance.Status
+
+	isRepStateSecondary := spec.ReplicationState == ramendrv1alpha1.Secondary
+	switchedToSecondary := status.State == ramendrv1alpha1.SecondaryState
+
+	return isRepStateSecondary &&
+		switchedToSecondary
+}
+
+func (v *VRGInstance) isSecondaryWithVolRepProtectedPVCs() bool {
+	return v.IsSecondaryVRG() && len(v.volRepPVCs) > 0
+}
+
+func (v *VRGInstance) validateSecondaryPVCConflictForVolRep() *metav1.Condition {
+	if v.IsDRActionInProgress() {
+		return nil
+	}
+
+	if v.isSecondaryWithVolRepProtectedPVCs() {
+		return updateVRGNoClusterDataConflictCondition(
+			v.instance.Generation, metav1.ConditionFalse, VRGConditionReasonClusterDataConflictSecondary,
+			"No PVC on the secondary should match the label selector",
+		)
+	}
+
+	return nil
 }

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -833,3 +833,52 @@ func (v *VRGInstance) doCleanupResources(name, namespace string) error {
 
 	return nil
 }
+
+func (v *VRGInstance) isSecondaryWithVolSyncProtectedPVCs() bool {
+	return v.IsSecondaryVRG() && len(v.volSyncPVCs) > 0
+}
+
+func (v *VRGInstance) validateSecondaryPVCConflictForVolsync() bool {
+	if !v.isSecondaryWithVolSyncProtectedPVCs() {
+		return false
+	}
+
+	// Validate that only replication destination PVCs match the label selector.
+	for _, pvc := range v.volSyncPVCs {
+		matchFound := false
+
+		for _, rdSpec := range v.instance.Spec.VolSync.RDSpec {
+			if pvc.GetName() == rdSpec.ProtectedPVC.Name &&
+				pvc.GetNamespace() == rdSpec.ProtectedPVC.Namespace {
+				matchFound = true
+
+				break // Found a match, no need to check further for this PVC
+			}
+		}
+
+		if !matchFound {
+			return true // No match found for this PVC, conflict detected!
+		}
+	}
+
+	return false // No conflicts found
+}
+
+func (v *VRGInstance) aggregateVolSyncClusterDataConflictCondition() *metav1.Condition {
+	noClusterDataConflictCondition := &metav1.Condition{
+		Status:             metav1.ConditionTrue,
+		Type:               VRGConditionTypeNoClusterDataConflict,
+		Reason:             VRGConditionReasonNoConflictDetected,
+		ObservedGeneration: v.instance.Generation,
+		Message:            "No PVC conflict detected for VolumeSync scheme",
+	}
+
+	if v.validateSecondaryPVCConflictForVolsync() {
+		return updateVRGNoClusterDataConflictCondition(v.instance.Generation,
+			metav1.ConditionFalse, VRGConditionReasonClusterDataConflictSecondary,
+			"A PVC that is not a replication destination should not match the label selector.",
+		)
+	}
+
+	return noClusterDataConflictCondition
+}


### PR DESCRIPTION
Handles the PVC conflict across primary and secondary clusters. And priotize the conflict on primary cluster over the secondary.


(cherry picked from commit 110c50ec26ea217d414140e9f4de0ad416421e2b)