### PR TITLE
DFBUGS-3851: recipe- support addition for CRs in check hooks

### DIFF
--- a/internal/controller/hooks/check_hook.go
+++ b/internal/controller/hooks/check_hook.go
@@ -21,8 +21,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const three = 3
-
 type CheckHook struct {
 	Hook   *kubeobjects.HookSpec
 	Reader client.Reader
@@ -179,6 +177,8 @@ func getResourcesList(k8sReader client.Reader, hook *kubeobjects.HookSpec, log l
 }
 
 func validateAndGetUnstructedListBasedOnType(resourceType string) (*unstructured.UnstructuredList, error) {
+	const three = 3
+
 	resourceParts := strings.Split(resourceType, "/")
 	if len(resourceParts) != 1 && len(resourceParts) != three {
 		return nil, fmt.Errorf("invalid resource type, supported resource types are pod/deployment/statefulset," +

--- a/internal/controller/hooks/check_hook.go
+++ b/internal/controller/hooks/check_hook.go
@@ -7,15 +7,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+const three = 3
 
 type CheckHook struct {
 	Hook   *kubeobjects.HookSpec
@@ -141,7 +147,7 @@ func ConvertClientObjectToMap(obj client.Object) (map[string]interface{}, error)
 func getResourcesList(k8sReader client.Reader, hook *kubeobjects.HookSpec, log logr.Logger) ([]client.Object, error) {
 	resourceList := make([]client.Object, 0)
 
-	objList, err := getObjectListBasedOnResourceType(hook.SelectResource)
+	uList, err := validateAndGetUnstructedListBasedOnType(hook.SelectResource)
 	if err != nil {
 		return resourceList, fmt.Errorf("error getting object list based on resource type: %w", err)
 	}
@@ -149,7 +155,7 @@ func getResourcesList(k8sReader client.Reader, hook *kubeobjects.HookSpec, log l
 	if hook.NameSelector != "" {
 		log.Info("getting resources using nameSelector", "nameSelector", hook.NameSelector)
 
-		objsUsingNameSelector, err := getResourcesUsingNameSelector(k8sReader, hook, objList)
+		objsUsingNameSelector, err := getResourcesUsingNameSelector(k8sReader, hook, uList)
 		if err != nil {
 			return resourceList, fmt.Errorf("error getting resources using nameSelector: %w", err)
 		}
@@ -160,65 +166,124 @@ func getResourcesList(k8sReader client.Reader, hook *kubeobjects.HookSpec, log l
 	if hook.LabelSelector != nil {
 		log.Info("getting resources using labelSelector", "labelSelector", hook.LabelSelector)
 
-		err := getResourcesUsingLabelSelector(k8sReader, hook, objList)
+		err := getResourcesUsingLabelSelector(k8sReader, hook, uList)
 		if err != nil {
 			return resourceList, fmt.Errorf("error getting resources using labelSelector: %w", err)
 		}
 
-		objsUsingLabelSelector := getObjectsBasedOnType(objList)
+		objsUsingLabelSelector := getObjectsBasedOnType(uList)
 		resourceList = append(resourceList, objsUsingLabelSelector...)
 	}
 
 	return resourceList, nil
 }
 
-func getObjectListBasedOnResourceType(selectResource string) (client.ObjectList, error) {
-	switch selectResource {
-	case podType:
-		return &corev1.PodList{}, nil
-	case deploymentType:
-		return &appsv1.DeploymentList{}, nil
-	case statefulsetType:
-		return &appsv1.StatefulSetList{}, nil
-	default:
-		return nil, fmt.Errorf("unsupported resource type %s", selectResource)
+func validateAndGetUnstructedListBasedOnType(resourceType string) (*unstructured.UnstructuredList, error) {
+	resourceParts := strings.Split(resourceType, "/")
+	if len(resourceParts) != 1 && len(resourceParts) != three {
+		return nil, fmt.Errorf("invalid resource type, supported resource types are pod/deployment/statefulset," +
+			"plural resource names for core or custom resource in the format <apiGroup>/<apiVersion>/<resourceName>")
 	}
+
+	list := &unstructured.UnstructuredList{}
+
+	// process resource given as one of the predefined types pod, deployment or statefulset
+	gvkMap := prepareMapForDefinedTypes()
+	if gvk, ok := gvkMap[resourceType]; ok {
+		list.SetGroupVersionKind(gvk)
+
+		return list, nil
+	}
+
+	mapper, err := getRestMapper()
+	if err != nil {
+		return list, err
+	}
+
+	// process resource given in the format <apiGroup>/<apiVersion>/<resource>
+	if len(resourceParts) == three {
+		gvr := schema.GroupVersionResource{
+			Group:    resourceParts[0],
+			Version:  resourceParts[1],
+			Resource: resourceParts[2],
+		}
+
+		gvk, err := convertGVRToGVK(mapper, gvr)
+		if err != nil {
+			return list, err
+		}
+
+		list.SetGroupVersionKind(*gvk)
+
+		return list, nil
+	}
+
+	// process resources given as serviceaccounts etc which belong to core apis
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: resourceType,
+	}
+
+	gvk, err := convertGVRToGVK(mapper, gvr)
+	if err != nil {
+		return list, fmt.Errorf("unrecognized core resource or invalid format: %w", err)
+	}
+
+	list.SetGroupVersionKind(*gvk)
+
+	return list, nil
 }
 
-func getMatchingPods(pList *corev1.PodList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, pod := range pList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
-		}
+func prepareMapForDefinedTypes() map[string]schema.GroupVersionKind {
+	gvkMap := make(map[string]schema.GroupVersionKind)
+	gvkMap["pod"] = schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
 	}
 
-	return objs
+	gvkMap["deployment"] = schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "Deployment",
+	}
+
+	gvkMap["statefulset"] = schema.GroupVersionKind{
+		Group:   "apps",
+		Version: "v1",
+		Kind:    "StatefulSet",
+	}
+
+	return gvkMap
 }
 
-func getMatchingDeployments(dList *appsv1.DeploymentList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, pod := range dList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
-		}
+func getRestMapper() (meta.RESTMapper, error) {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
 	}
 
-	return objs
+	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	apiGroupResources, err := restmapper.GetAPIGroupResources(dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return restmapper.NewDiscoveryRESTMapper(apiGroupResources), nil
 }
 
-func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, pod := range ssList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
-		}
+func convertGVRToGVK(mapper meta.RESTMapper, gvr schema.GroupVersionResource) (*schema.GroupVersionKind, error) {
+	gvk, err := mapper.KindFor(gvr)
+	if err != nil {
+		return nil, err
 	}
 
-	return objs
+	return &gvk, nil
 }
 
 func EvaluateCheckHookExp(booleanExpression string, jsonData interface{}) (bool, error) {

--- a/internal/controller/hooks/check_hook_test.go
+++ b/internal/controller/hooks/check_hook_test.go
@@ -4,16 +4,22 @@
 package hooks_test
 
 import (
+	"context"
 	"encoding/json"
 	"strconv"
 	"testing"
 
+	rmnv1 "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/internal/controller/hooks"
 	"github.com/ramendr/ramen/internal/controller/kubeobjects"
+	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
@@ -219,6 +225,32 @@ var testCasesObjectData = []testCasesObject{
 	},
 }
 
+func setupFakeClient(t *testing.T) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	err = appsv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	err = rmnv1.AddToScheme(scheme)
+	assert.NoError(t, err)
+
+	// nolint:errcheck
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithIndex(&corev1.Pod{}, "metadata.name", func(obj client.Object) []string {
+			return []string{obj.(*corev1.Pod).Name}
+		}).
+		WithIndex(&appsv1.Deployment{}, "metadata.name", func(obj client.Object) []string {
+			return []string{obj.(*unstructured.Unstructured).GetName()}
+		}).Build()
+	assert.NotNil(t, fakeClient)
+
+	return fakeClient
+}
+
 func getHookSpec(resourceType, condition string) *kubeobjects.HookSpec {
 	return &kubeobjects.HookSpec{
 		Name:           "test-hook",
@@ -228,6 +260,102 @@ func getHookSpec(resourceType, condition string) *kubeobjects.HookSpec {
 			Condition: condition,
 		},
 	}
+}
+
+func TestExecutCheckHookForPodWithNoSelector(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+
+	assert.NotNil(t, fakeClient)
+
+	pod := getPodSpec("busybox")
+	err := fakeClient.Create(context.Background(), pod)
+	assert.Nil(t, err)
+
+	cHook := hooks.CheckHook{
+		Hook:   getHookSpec("pod", "{$.status.phase} == {Running}"),
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.NotNil(t, err)
+}
+
+func TestExecutCheckHookForPodWithNameSelector(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+	assert.NotNil(t, fakeClient)
+
+	pod := getPodSpec("busybox")
+	pod.Status.Phase = "Running"
+	err := fakeClient.Create(context.Background(), pod)
+	assert.Nil(t, err)
+
+	pod = getPodSpec("busybox1")
+	err = fakeClient.Create(context.Background(), pod)
+	assert.Nil(t, err)
+
+	hook := getHookSpec("pod", "{$.status.phase} == {Running}")
+	hook.NameSelector = "busybox"
+
+	cHook := hooks.CheckHook{
+		Hook:   hook,
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.Nil(t, err)
+}
+
+func TestExecuteCheckHookForDeployment(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+	assert.NotNil(t, fakeClient)
+
+	dep := getDeploymentContent()
+
+	err := fakeClient.Create(context.Background(), dep)
+	assert.Nil(t, err)
+
+	hook := getHookSpec("deployment", "{$.spec.replicas} == {$.status.replicas}")
+	hook.NameSelector = "test-deploy"
+
+	cHook := hooks.CheckHook{
+		Hook:   hook,
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.Nil(t, err)
+}
+
+func TestExecuteCheckHookForStatefulSet(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+	assert.NotNil(t, fakeClient)
+
+	ss := getStatefulSetContent()
+	ss.Labels = map[string]string{
+		"appname": "test",
+	}
+
+	err := fakeClient.Create(context.Background(), ss)
+	assert.Nil(t, err)
+
+	hook := getHookSpec("statefulset", "{$.spec.replicas} != {$.status.readyReplicas}")
+	hook.LabelSelector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			"appname": "test",
+		},
+	}
+
+	cHook := hooks.CheckHook{
+		Hook:   hook,
+		Reader: fakeClient,
+	}
+
+	log := zap.New(zap.UseDevMode(true))
+	err = cHook.Execute(log)
+	assert.Nil(t, err)
 }
 
 func TestEvaluateCheckHookExp(t *testing.T) {

--- a/internal/controller/hooks/hooks_util.go
+++ b/internal/controller/hooks/hooks_util.go
@@ -10,7 +10,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,9 +50,6 @@ func getObjectsUsingValidK8sName(r client.Reader, hook *kubeobjects.HookSpec,
 ) ([]client.Object, error) {
 	listOps := &client.ListOptions{
 		Namespace: hook.Namespace,
-		FieldSelector: fields.SelectorFromSet(fields.Set{
-			"metadata.name": hook.NameSelector, // needs exact matching with the name
-		}),
 	}
 
 	err := r.List(context.Background(), objList, listOps)
@@ -61,7 +57,53 @@ func getObjectsUsingValidK8sName(r client.Reader, hook *kubeobjects.HookSpec,
 		return nil, fmt.Errorf("error listing resources using nameSelector: %w", err)
 	}
 
-	return getObjectsBasedOnType(objList), err
+	return getFilteredObjectsBasedOnTypeAndNameSelector(objList, hook.NameSelector), err
+}
+
+// Based on the type of resource, slice of objects is returned.
+func getFilteredObjectsBasedOnTypeAndNameSelector(objList client.ObjectList, nameSelector string) []client.Object {
+	objs := make([]client.Object, 0)
+
+	switch v := objList.(type) {
+	case *unstructured.UnstructuredList:
+		objs = filterUnstructuredObjects(v.Items, nameSelector)
+	case *corev1.PodList:
+		objs = filterPods(v.Items, nameSelector)
+	case *appsv1.DeploymentList:
+		objs = filterDeployments(v.Items, nameSelector)
+	case *appsv1.StatefulSetList:
+		objs = filterStatefulSets(v.Items, nameSelector)
+	}
+
+	return objs
+}
+
+func filterStatefulSets(objs []appsv1.StatefulSet, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterDeployments(objs []appsv1.Deployment, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterPods(objs []corev1.Pod, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterUnstructuredObjects(objs []unstructured.Unstructured, nameSelector string) []client.Object {
+	return filterObjectsSameAsNameSelector(toPointerSlice(objs), nameSelector)
+}
+
+func filterObjectsSameAsNameSelector[T client.Object](objs []T, nameSelector string) []client.Object {
+	filteredObjs := make([]client.Object, 0, len(objs))
+
+	for _, obj := range objs {
+		if obj.GetName() == nameSelector {
+			filteredObjs = append(filteredObjs, obj)
+		}
+	}
+
+	return filteredObjs
 }
 
 // Based on the type of resource, slice of objects is returned.
@@ -186,49 +228,39 @@ func getOpHookTimeoutValue(hook *kubeobjects.HookSpec) int {
 }
 
 func getMatchingUnstructedObjs(uList *unstructured.UnstructuredList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, uObj := range uList.Items {
-		if re.MatchString(uObj.GetName()) {
-			objs = append(objs, &uObj)
-		}
-	}
-
-	return objs
+	return getRegexMatchingObjects(toPointerSlice(uList.Items), re)
 }
 
 func getMatchingPods(pList *corev1.PodList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, pod := range pList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
-		}
-	}
-
-	return objs
+	return getRegexMatchingObjects(toPointerSlice(pList.Items), re)
 }
 
 func getMatchingDeployments(dList *appsv1.DeploymentList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
+	return getRegexMatchingObjects(toPointerSlice(dList.Items), re)
+}
 
-	for _, pod := range dList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
+func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) []client.Object {
+	return getRegexMatchingObjects(toPointerSlice(ssList.Items), re)
+}
+
+func getRegexMatchingObjects[T client.Object](items []T, re *regexp.Regexp) []client.Object {
+	objs := make([]client.Object, 0, len(items))
+
+	for _, item := range items {
+		if re.MatchString(item.GetName()) {
+			obj := item
+			objs = append(objs, obj)
 		}
 	}
 
 	return objs
 }
 
-func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) []client.Object {
-	objs := make([]client.Object, 0)
-
-	for _, pod := range ssList.Items {
-		if re.MatchString(pod.Name) {
-			objs = append(objs, &pod)
-		}
+func toPointerSlice[T any](items []T) []*T {
+	ptrs := make([]*T, len(items))
+	for i := range items {
+		ptrs[i] = &items[i]
 	}
 
-	return objs
+	return ptrs
 }

--- a/internal/controller/hooks/hooks_util.go
+++ b/internal/controller/hooks/hooks_util.go
@@ -9,6 +9,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -68,6 +69,10 @@ func getObjectsBasedOnType(objList client.ObjectList) []client.Object {
 	objs := make([]client.Object, 0)
 
 	switch v := objList.(type) {
+	case *unstructured.UnstructuredList:
+		for _, uObj := range v.Items {
+			objs = append(objs, &uObj)
+		}
 	case *corev1.PodList:
 		for _, pod := range v.Items {
 			objs = append(objs, &pod)
@@ -95,6 +100,8 @@ func getObjectsBasedOnTypeAndRegex(objList client.ObjectList, nameSelector strin
 	}
 
 	switch v := objList.(type) {
+	case *unstructured.UnstructuredList:
+		objs = getMatchingUnstructedObjs(v, re)
 	case *corev1.PodList:
 		objs = getMatchingPods(v, re)
 	case *appsv1.DeploymentList:
@@ -176,4 +183,52 @@ func getOpHookTimeoutValue(hook *kubeobjects.HookSpec) int {
 	}
 	// 300s is the default value for timeout
 	return defaultTimeoutValue
+}
+
+func getMatchingUnstructedObjs(uList *unstructured.UnstructuredList, re *regexp.Regexp) []client.Object {
+	objs := make([]client.Object, 0)
+
+	for _, uObj := range uList.Items {
+		if re.MatchString(uObj.GetName()) {
+			objs = append(objs, &uObj)
+		}
+	}
+
+	return objs
+}
+
+func getMatchingPods(pList *corev1.PodList, re *regexp.Regexp) []client.Object {
+	objs := make([]client.Object, 0)
+
+	for _, pod := range pList.Items {
+		if re.MatchString(pod.Name) {
+			objs = append(objs, &pod)
+		}
+	}
+
+	return objs
+}
+
+func getMatchingDeployments(dList *appsv1.DeploymentList, re *regexp.Regexp) []client.Object {
+	objs := make([]client.Object, 0)
+
+	for _, pod := range dList.Items {
+		if re.MatchString(pod.Name) {
+			objs = append(objs, &pod)
+		}
+	}
+
+	return objs
+}
+
+func getMatchingStatefulSets(ssList *appsv1.StatefulSetList, re *regexp.Regexp) []client.Object {
+	objs := make([]client.Object, 0)
+
+	for _, pod := range ssList.Items {
+		if re.MatchString(pod.Name) {
+			objs = append(objs, &pod)
+		}
+	}
+
+	return objs
 }


### PR DESCRIPTION
As of now the supported resource types were pod, deployment and statefulset. Additional changes have been done to support for any Custom Resources(CRs) for which the supported format of the resource is of the form //. Additional user responsibility is to add the required Role and RoleBinding combination on the cluster.

[Original PR](https://github.com/RamenDR/ramen/pull/2211)