### PR TITLE
DFBUGS-2917: Fix missing velero exclude labels on VolSync/Submariner Resources

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -118,6 +118,7 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupDestination(
 	}
 
 	util.AddLabel(rgd, util.CreatedByRamenLabel, "true")
+	util.AddLabel(rgd, util.ExcludeFromVeleroBackup, "true")
 
 	_, err := ctrlutil.CreateOrUpdate(c.ctx, c.Client, rgd, func() error {
 		util.AddLabel(rgd, volsync.VRGOwnerNameLabel, c.instance.GetName())
@@ -207,6 +208,7 @@ func (c *cgHandler) CreateOrUpdateReplicationGroupSource(
 	}
 
 	util.AddLabel(rgs, util.CreatedByRamenLabel, "true")
+	util.AddLabel(rgs, util.ExcludeFromVeleroBackup, "true")
 
 	_, err = ctrlutil.CreateOrUpdate(c.ctx, c.Client, rgs, func() error {
 		util.AddLabel(rgs, volsync.VRGOwnerNameLabel, c.instance.GetName())

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -391,9 +391,13 @@ func getBackupSpecFromObjectsSpec(objectsSpec kubeobjects.Spec) velero.BackupSpe
 		IncludedNamespaces: objectsSpec.IncludedNamespaces,
 		IncludedResources:  objectsSpec.IncludedResources,
 		// exclude VRs from Backup so VRG can create them: see https://github.com/RamenDR/ramen/issues/884
+		// exclude EndpointSlices/Endpoints to prevent Submariner conflicts: see https://github.com/RamenDR/ramen/issues/1889
+		// exclude VolumeSnapshots and VolumeGroupSnapshots from backup
 		ExcludedResources: append(objectsSpec.ExcludedResources, "volumereplications.replication.storage.openshift.io",
-			"replicationsources.volsync.backube", "replicationdestinations.volsync.backube",
-			"PersistentVolumeClaims", "PersistentVolumes"),
+			"volumegroupreplications.replication.storage.openshift.io", "replicationsources.volsync.backube",
+			"replicationdestinations.volsync.backube", "PersistentVolumeClaims", "PersistentVolumes",
+			"endpointslices.discovery.k8s.io", "endpoints", "volumesnapshots.snapshot.storage.k8s.io",
+			"volumegroupsnapshots.groupsnapshot.storage.k8s.io"),
 		LabelSelector:           newLabelSelector,
 		OrLabelSelectors:        objectsSpec.OrLabelSelectors,
 		TTL:                     metav1.Duration{}, // TODO: set default here

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -1023,8 +1023,17 @@ func (v *VSHandler) CopySecretToPVCNamespace(secretName, namespace string) error
 	}
 
 	if err == nil {
-		v.log.Info("Secret already exists in the PVC namespace", "secretName", secretName, "pvcNamespace",
-			namespace)
+		util.AddLabel(secret, util.CreatedByRamenLabel, "true")
+		util.AddLabel(secret, util.ExcludeFromVeleroBackup, "true")
+
+		if err := v.client.Update(v.ctx, secret); err != nil {
+			v.log.Error(err, "Failed to update existing secret with ramen labels", "secretName", secretName)
+
+			return fmt.Errorf("error updating existing secret with ramen labels (%w)", err)
+		}
+
+		v.log.Info("Secret already exists in the PVC namespace and updated with ramen labels",
+			"secretName", secretName, "pvcNamespace", namespace)
 
 		return nil
 	}
@@ -1049,6 +1058,10 @@ func (v *VSHandler) CopySecretToPVCNamespace(secretName, namespace string) error
 		Labels:      secret.Labels,
 		Annotations: secret.Annotations,
 	}
+
+	// Ensure the copied secret has ramen labels for velero exclusion
+	util.AddLabel(secretCopy, util.CreatedByRamenLabel, "true")
+	util.AddLabel(secretCopy, util.ExcludeFromVeleroBackup, "true")
 
 	err = v.client.Create(v.ctx, secretCopy)
 	if err != nil {
@@ -1303,6 +1316,10 @@ func (v *VSHandler) ReconcileServiceExportForRD(rd *volsyncv1alpha1.ReplicationD
 	})
 
 	op, err := ctrlutil.CreateOrUpdate(v.ctx, v.client, svcExport, func() error {
+		// Add ramen labels to ensure this ServiceExport is excluded from velero backups
+		util.AddLabel(svcExport, util.CreatedByRamenLabel, "true")
+		util.AddLabel(svcExport, util.ExcludeFromVeleroBackup, "true")
+
 		// Make this ServiceExport owned by the replication destination itself rather than the VRG
 		// This way on relocate scenarios or failover/failback, when the RD is cleaned up the associated
 		// ServiceExport will get cleaned up with it.

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -785,6 +785,8 @@ func (v *VRGInstance) createVGR(vrNamespacedName types.NamespacedName,
 		},
 	}
 
+	rmnutil.AddLabel(volRep, rmnutil.CreatedByRamenLabel, "true")
+
 	if !vrgInAdminNamespace(v.instance, v.ramenConfig) {
 		// This is to keep existing behavior of ramen.
 		// Set the owner reference only for the VRs which are in the same namespace as the VRG and


### PR DESCRIPTION
Following resources now excluded from Velero backups:

VolSync Infrastructure:

ReplicationDestination
ReplicationSource
VolumeReplication
VolumeGroupReplication
ReplicationGroupDestination
ReplicationGroupSource
Copied secrets in application namespaces
Submariner Resources:

ServiceExport
EndpointSlices
Endpoints
Storage Resources:

VolumeSnapshots
VolumeGroupSnapshots

[Original PR](https://github.com/RamenDR/ramen/pull/2247) 