### PR TITLE
DFBUGS-3662: Fix type assertion error in DeleteTypedObjectList

### DIFF
--- a/internal/controller/cephfscg/cghandler.go
+++ b/internal/controller/cephfscg/cghandler.go
@@ -487,16 +487,8 @@ func ListReplicationGroupByOwner(ctx context.Context, k8sClient client.Client, o
 func DeleteTypedObjectList[T client.Object](ctx context.Context, k8sClient client.Client, items []T, logger logr.Logger,
 ) error {
 	for _, obj := range items {
-		// Ensure obj is a pointer
-		objCopy := obj
-
-		objPtr, ok := any(&objCopy).(client.Object)
-		if !ok {
-			return fmt.Errorf("obj is not a client.Object")
-		}
-
-		if err := k8sClient.Delete(ctx, objPtr); err != nil {
-			logger.Error(err, "Error cleaning up object", "name", objPtr.GetName())
+		if err := k8sClient.Delete(ctx, obj); err != nil {
+			logger.Error(err, "Error cleaning up object", "name", obj.GetName())
 		}
 	}
 

--- a/internal/controller/cephfscg/cghandler_test.go
+++ b/internal/controller/cephfscg/cghandler_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/volsync"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +44,7 @@ var _ = Describe("Cghandler", func() {
 				Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 					Async: &ramendrv1alpha1.VRGAsyncSpec{},
 				},
-			}, nil, nil, "0", testLogger)
+			}, nil, nil, rgdName, testLogger)
 			rgd, err := vsCGHandler.CreateOrUpdateReplicationGroupDestination(vgdName, "default", nil)
 			Expect(err).To(BeNil())
 			Expect(len(rgd.Spec.RDSpecs)).To(Equal(0))
@@ -58,7 +59,7 @@ var _ = Describe("Cghandler", func() {
 				Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 					Async: &ramendrv1alpha1.VRGAsyncSpec{},
 				},
-			}, nil, nil, "0", testLogger)
+			}, nil, nil, rgdName, testLogger)
 			rgd, err := vsCGHandler.CreateOrUpdateReplicationGroupDestination(vgdName, "default",
 				[]ramendrv1alpha1.VolSyncReplicationDestinationSpec{{
 					ProtectedPVC: ramendrv1alpha1.ProtectedPVC{
@@ -68,6 +69,15 @@ var _ = Describe("Cghandler", func() {
 				}})
 			Expect(err).To(BeNil())
 			Expect(len(rgd.Spec.RDSpecs)).To(Equal(1))
+			Expect(cephfscg.DeleteRGD(Ctx, k8sClient, vgdName, "default", testLogger)).To(BeNil())
+			Eventually(func() bool {
+				err := k8sClient.Get(Ctx, types.NamespacedName{
+					Name:      rgdName,
+					Namespace: "default",
+				}, rgd)
+
+				return k8serrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 	Describe("CreateOrUpdateReplicationGroupSource", func() {
@@ -169,12 +179,21 @@ var _ = Describe("Cghandler", func() {
 				Spec: ramendrv1alpha1.VolumeReplicationGroupSpec{
 					Async: &ramendrv1alpha1.VRGAsyncSpec{},
 				},
-			}, &metav1.LabelSelector{}, nil, "0", testLogger)
+			}, &metav1.LabelSelector{}, nil, rgsName, testLogger)
 			rgs, finalSync, err := vsCGHandler.CreateOrUpdateReplicationGroupSource(rgsName, "default", false)
 			Expect(err).To(BeNil())
 			Expect(finalSync).To(BeFalse())
 			Expect(rgs.Spec.Trigger.Schedule).NotTo(BeNil())
 			Expect(*rgs.Spec.Trigger.Schedule).NotTo(BeEmpty())
+			Expect(cephfscg.DeleteRGS(Ctx, k8sClient, vrgName, "default", testLogger)).To(BeNil())
+			Eventually(func() bool {
+				err := k8sClient.Get(Ctx, types.NamespacedName{
+					Name:      rgsName,
+					Namespace: "default",
+				}, rgs)
+
+				return k8serrors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 	Describe("GetLatestImageFromRGD", func() {


### PR DESCRIPTION
Taking &objCopy results in a double pointer (**T) which does not satisfy the client.Object interface. The fix uses objCopy directly, assuming T is already a pointer to a type that implements client.Object.

(cherry picked from commit 696e91a92538319af1791a3a8254bd71261456a4)