### PR TITLE
DFBUGS-4220, DFBUGS-4224: Add BSL validation before creating backup

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -286,6 +286,7 @@ rules:
   - delete
   - deletecollection
   - get
+  - list
   - patch
   - update
 - apiGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -401,6 +401,7 @@ rules:
   - delete
   - deletecollection
   - get
+  - list
   - patch
   - update
 - apiGroups:


### PR DESCRIPTION
Fixes backup/restore issue with OADP-1.5.1
Wait for BackupStorageLocation to become Available before creating backup to prevent FailedValidation

Fixes: [DFBUGS-4220](https://issues.redhat.com//browse/DFBUGS-4220), [DFBUGS-4224](https://issues.redhat.com//browse/DFBUGS-4224)

(cherry picked from commit aa3a62fd3a650cb90dc2d5465825a9c9d93ccc9c)