### PR TITLE
DFBUGS-6689: Backport global VGR status handling fixes and PVC restore update improvements

### DIFF
--- a/internal/controller/protected_condition.go
+++ b/internal/controller/protected_condition.go
@@ -294,7 +294,9 @@ func updateMiscVRGStatus(drpc *rmn.DRPlacementControl,
 		return updated
 	}
 
-	if vrg.Spec.Async != nil && vrg.Spec.Async.SchedulingInterval != "0m" && vrg.Status.LastGroupSyncTime.IsZero() {
+	if vrg.Spec.Async != nil &&
+		vrg.GetLabels()[GlobalVGRLabel] == "" &&
+		(vrg.Status.LastGroupSyncTime == nil || vrg.Status.LastGroupSyncTime.IsZero()) {
 		addOrUpdateCondition(&drpc.Status.Conditions, rmn.ConditionProtected, drpc.Generation, metav1.ConditionFalse,
 			rmn.ReasonProtectedProgressing, fmt.Sprintf("VolumeReplicationGroup (%s/%s) on cluster %s "+
 				"is not reporting any lastGroupSyncTime as %s, retrying till status is met",

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -434,10 +434,7 @@ func (v *VRGInstance) getVGRUsingSCLabel(pvc *corev1.PersistentVolumeClaim) (*vo
 		return nil, fmt.Errorf("error determining replicationID")
 	}
 
-	vgrNamespacedName := types.NamespacedName{
-		Name:      rmnutil.CreateVGRName(grID, v.instance.Name),
-		Namespace: pvc.Namespace,
-	}
+	vgrNamespacedName := v.vgrNamespacedName(grID, pvc.Namespace)
 
 	vgr := &volrep.VolumeGroupReplication{}
 	err = v.reconciler.Get(v.ctx, vgrNamespacedName, vgr)

--- a/internal/controller/vrg_volgrouprep_global.go
+++ b/internal/controller/vrg_volgrouprep_global.go
@@ -223,21 +223,20 @@ func (v *VRGInstance) isGlobalVGRStateMatched(
 	}
 }
 
-// validateGlobalVGRStatus short-circuits VGR status validation for global VGRs
-// with schedulingInterval "0m". Since the storage provider manages replication
-// externally and does not report Completed/Degraded/Resyncing conditions,
-// DataReady is derived from the VGR state match and DataProtected is set based
-// on the storage provider managing protection externally.
-// For non-zero intervals, returns false to let the normal validation path handle it.
+// validateGlobalVGRStatus short-circuits VGR status validation for global VGRs.
+// Since the storage provider manages replication externally and does not report
+// Completed/Degraded/Resyncing conditions, DataReady is derived from the VGR
+// state match and DataProtected is set based on the storage provider managing
+// protection externally. This applies to any scheduling interval as long as
+// the VRG has the global VGR label.
 //
-// TODO: When storage providers with schedulingInterval "0m" start reporting
-// status conditions, update this function to fall through to the normal
-// validation path instead of short-circuiting.
+// TODO: When storage providers start reporting status conditions, update this function
+// to fall through to the normal validation path instead of short-circuiting.
 func (v *VRGInstance) validateGlobalVGRStatus(
 	volRep client.Object, pvcs []*corev1.PersistentVolumeClaim,
 	status *volrep.VolumeReplicationStatus, state ramendrv1alpha1.ReplicationState,
 ) bool {
-	if v.instance.Spec.Async == nil || v.instance.Spec.Async.SchedulingInterval != "0m" {
+	if !v.hasGlobalVGRLabel() {
 		return false
 	}
 

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2352,15 +2352,29 @@ func (v *VRGInstance) checkPVClusterData(pvList []corev1.PersistentVolume) error
 
 func handleExistingObject[
 	ObjectType any,
+	ClientObject interface {
+		*ObjectType
+		client.Object
+	},
 ](
 	v *VRGInstance,
-	object *ObjectType,
+	object *ObjectType, obj ClientObject,
 	validateExistingObject func(*ObjectType) error,
 ) bool {
 	if err := validateExistingObject(object); err != nil {
 		v.log.Info("Object exists. Ignoring and moving to next object", "error", err.Error())
 
 		return false
+	}
+
+	// Valid object exists and it is managed by Ramen
+	// If it's a PVC, update it; otherwise just count it as restored
+	if pvc, ok := any(obj).(*corev1.PersistentVolumeClaim); ok {
+		if err := v.reconciler.Update(v.ctx, pvc); err != nil {
+			v.log.Info("Failed to update existing PVC", "name", pvc.GetName(), "error", err.Error())
+
+			return false
+		}
 	}
 
 	return true
@@ -2396,7 +2410,7 @@ func restoreClusterDataObjects[
 
 		if err := v.reconciler.Create(v.ctx, obj); err != nil {
 			if k8serrors.IsAlreadyExists(err) {
-				if handleExistingObject(v, object, validateExistingObject) {
+				if handleExistingObject(v, object, obj, validateExistingObject) {
 					numRestored++
 				}
 
@@ -2660,6 +2674,7 @@ func cleanupPVCForRestore(pvc *corev1.PersistentVolumeClaim) error {
 	pvc.ObjectMeta.Finalizers = []string{}
 	pvc.ObjectMeta.ResourceVersion = ""
 	pvc.ObjectMeta.OwnerReferences = nil
+	pvc.ObjectMeta.UID = ""
 
 	return nil
 }

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -253,9 +253,8 @@ func (v *VRGInstance) addPVCToGroupPVCs(
 	cg string,
 	groupPVCs map[types.NamespacedName][]*corev1.PersistentVolumeClaim,
 ) {
-	vgrName := rmnutil.CreateVGRName(cg, v.instance.Name)
-	vgrNamespacedName := types.NamespacedName{Name: vgrName, Namespace: pvc.Namespace}
-	groupPVCs[vgrNamespacedName] = append(groupPVCs[vgrNamespacedName], pvc)
+	vgrKey := v.vgrNamespacedName(cg, pvc.Namespace)
+	groupPVCs[vgrKey] = append(groupPVCs[vgrKey], pvc)
 }
 
 func (v *VRGInstance) reconcilePVCVRAsSecondary(pvc *corev1.PersistentVolumeClaim, log logr.Logger) bool {


### PR DESCRIPTION
- global-vgr: Use Global VGR label for status check and protected condition
- global-vgr: Fix to use global VGR namespacedName
- Update PVC resource when it already exists during restore