### PR TITLE
DFBUGS-6385: Fix fencing issues with multiple NetworkFenceClasses

### DIFF
--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -1218,10 +1218,27 @@ func (u *drclusterInstance) cleanClusters(clusters []ramen.DRCluster) (bool, err
 func (u *drclusterInstance) removeFencingCR(cluster ramen.DRCluster) (bool, error) {
 	u.log.Info(fmt.Sprintf("cleaning the cluster fence resource from the cluster %s", cluster.Name))
 
-	err := u.mwUtil.DeleteManifestWork(fmt.Sprintf(util.ManifestWorkNameFormat,
-		u.object.Name, cluster.Name, util.MWTypeNF), cluster.Name)
+	// Get NFCs to determine which ManifestWorks to delete
+	nfClasses, err := u.getNFClassesFromDRClusterConfig(&cluster)
 	if err != nil {
-		return true, fmt.Errorf("failed to delete NetworkFence resource from cluster %s", cluster.Name)
+		return true, fmt.Errorf("failed to get NetworkFenceClasses: %w", err)
+	}
+
+	// Delete ManifestWork for each NetworkFenceClass
+	for _, nfClass := range nfClasses {
+		name := u.object.Name
+		// Append NFC name to match the naming pattern used during creation
+		if nfClass != "" {
+			name += "-" + nfClass
+		}
+
+		mwName := fmt.Sprintf(util.ManifestWorkNameFormat, name, cluster.Name, util.MWTypeNF)
+
+		err := u.mwUtil.DeleteManifestWork(mwName, cluster.Name)
+		if err != nil {
+			return true, fmt.Errorf("failed to delete NetworkFence MW %s from cluster %s: %w",
+				mwName, cluster.Name, err)
+		}
 	}
 
 	return false, nil

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -1053,33 +1053,44 @@ func (u *drclusterInstance) clusterUnfence() (bool, error) {
 			u.object.Name, err)
 	}
 
-	processUnfence := func(networkFenceClassName string) (bool, error) {
-		requeue, err := u.unfenceClusterOnCluster(&peerCluster, networkFenceClassName)
-		if err != nil {
-			return requeue, fmt.Errorf("unfence operation to unfence cluster %s on cluster %s failed: %w",
-				u.object.Name, peerCluster.Name, err)
-		}
-
-		if requeue {
-			u.log.Info("requing as cluster unfence operation is not complete")
-
-			return requeue, nil
-		}
-
-		return false, nil
-	}
-
 	nfClasses, err := u.getNFClassesFromDRClusterConfig(&peerCluster)
 	if err != nil {
 		return true, fmt.Errorf("failed to get NetworkFenceClasses: %w", err)
 	}
 
+	// If not unfencing yet, create ALL ManifestWorks for all NetworkFenceClasses
+	if !u.isUnfencingOrUnfenced() {
+		u.log.Info(fmt.Sprintf("initiating the cluster unfence from the cluster %s", peerCluster.Name))
+
+		for _, nfClass := range nfClasses {
+			if err := u.createNFManifestWork(u.object, &peerCluster, u.log, nfClass); err != nil {
+				setDRClusterUnfencingFailedCondition(&u.object.Status.Conditions, u.object.Generation,
+					fmt.Sprintf("NetworkFence ManifestWork for unfence failed: %v", err))
+
+				return true, fmt.Errorf("failed to generate NetworkFence MW on cluster %s to unfence %s: %w",
+					peerCluster.Name, u.object.Name, err)
+			}
+		}
+
+		setDRClusterUnfencingCondition(&u.object.Status.Conditions, u.object.Generation,
+			"ManifestWork for NetworkFence unfence operation created")
+		u.setDRClusterPhase(ramen.Unfencing)
+		// just created unfencing resources. Requeue and then check.
+		return true, nil
+	}
+
+	// Already unfencing, check ALL NetworkFence statuses
 	for _, nfClass := range nfClasses {
-		requeue, err := processUnfence(nfClass)
-		if requeue || err != nil {
-			return requeue, err
+		err := u.checkUnfenceStatus(&peerCluster, nfClass)
+		if err != nil {
+			return true, err
 		}
 	}
+
+	// All NetworkFences succeeded
+	setDRClusterUnfencedCondition(&u.object.Status.Conditions, u.object.Generation,
+		"Cluster successfully unfenced")
+	u.advanceToNextPhase()
 
 	// once this cluster is unfenced. Clean the fencing resource.
 	return u.cleanClusters([]ramen.DRCluster{*u.object, peerCluster})
@@ -1119,45 +1130,10 @@ func (u *drclusterInstance) checkFenceStatus(peerCluster *ramen.DRCluster,
 	return nil
 }
 
-// if the fencing CR (via MCV) exist; then
-//
-//	if the status of fencing CR shows unfenced
-//	   return dontRequeue, nil
-//	else
-//	   return requeue, error
-//	endif
-//
-// else
-//
-//	Create the fencing CR MW with Unfenced state
-//	return requeue, nil
-//
-// endif
-func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster,
+// checkUnfenceStatus checks the status of a NetworkFence unfence resource via ManagedClusterView
+func (u *drclusterInstance) checkUnfenceStatus(peerCluster *ramen.DRCluster,
 	networkFenceClassName string,
-) (bool, error) {
-	if !u.isUnfencingOrUnfenced() {
-		u.log.Info(fmt.Sprintf("initiating the cluster unfence from the cluster %s", peerCluster.Name))
-
-		if err := u.createNFManifestWork(u.object, peerCluster, u.log, networkFenceClassName); err != nil {
-			setDRClusterUnfencingFailedCondition(&u.object.Status.Conditions, u.object.Generation,
-				"NeworkFence ManifestWork for unfence failed")
-
-			u.log.Info(fmt.Sprintf("Failed to generate NetworkFence MW on cluster %s to unfence %s",
-				peerCluster.Name, u.object.Name))
-
-			return true, fmt.Errorf("failed to generate NetworkFence MW on cluster %s to unfence %s",
-				peerCluster.Name, u.object.Name)
-		}
-
-		setDRClusterUnfencingCondition(&u.object.Status.Conditions, u.object.Generation,
-			"ManifestWork for NetworkFence unfence operation created")
-		u.setDRClusterPhase(ramen.Unfencing)
-
-		// just created NetworkFence resource to unfence. Requeue and then check.
-		return true, nil
-	}
-
+) error {
 	annotations := make(map[string]string)
 	annotations[DRClusterNameAnnotation] = u.object.Name
 
@@ -1168,11 +1144,11 @@ func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster
 			return u.requeueIfNFMWExists(peerCluster)
 		}
 
-		return true, fmt.Errorf("failed to get NetworkFence using MCV (error: %w", err)
+		return fmt.Errorf("failed to get NetworkFence using MCV (error: %w", err)
 	}
 
 	if nf.Spec.FenceState != csiaddonsv1alpha1.FenceState(u.object.Spec.ClusterFence) {
-		return true, fmt.Errorf("fence state in the NetworkFence resource is not changed to %v yet",
+		return fmt.Errorf("fence state in the NetworkFence resource is not changed to %v yet",
 			u.object.Spec.ClusterFence)
 	}
 
@@ -1182,29 +1158,25 @@ func (u *drclusterInstance) unfenceClusterOnCluster(peerCluster *ramen.DRCluster
 
 		u.log.Info("Unfencing operation not successful", "cluster", u.object.Name)
 
-		return true, fmt.Errorf("un operation result not successful")
+		return fmt.Errorf("un operation result not successful")
 	}
 
-	setDRClusterUnfencedCondition(&u.object.Status.Conditions, u.object.Generation,
-		"Cluster successfully unfenced")
-	u.advanceToNextPhase()
-
-	return false, nil
+	return nil
 }
 
-func (u *drclusterInstance) requeueIfNFMWExists(peerCluster *ramen.DRCluster) (bool, error) {
+func (u *drclusterInstance) requeueIfNFMWExists(peerCluster *ramen.DRCluster) error {
 	_, mwErr := u.mwUtil.FindManifestWorkByType(util.MWTypeNF, peerCluster.Name)
 	if mwErr != nil {
 		if k8serrors.IsNotFound(mwErr) {
 			u.log.Info("NetworkFence and MW for it not found. Cleaned")
 
-			return false, nil
+			return nil
 		}
 
-		return true, fmt.Errorf("failed to get MW for NetworkFence %w", mwErr)
+		return fmt.Errorf("failed to get MW for NetworkFence %w", mwErr)
 	}
 
-	return true, fmt.Errorf("NetworkFence not found. But MW still exists")
+	return fmt.Errorf("NetworkFence not found. But MW still exists")
 }
 
 // We are here means following things have been confirmed.

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -993,12 +993,39 @@ func (u *drclusterInstance) clusterFence() (bool, error) {
 		return true, fmt.Errorf("failed to get NetworkFenceClasses: %w", err)
 	}
 
+	// If not fencing yet, create ALL ManifestWorks for all NetworkFenceClasses
+	if !u.isFencingOrFenced() {
+		u.log.Info(fmt.Sprintf("initiating the cluster fence from the cluster %s", peerCluster.Name))
+
+		for _, nfClass := range nfClasses {
+			if err := u.createNFManifestWork(u.object, &peerCluster, u.log, nfClass); err != nil {
+				setDRClusterFencingFailedCondition(&u.object.Status.Conditions, u.object.Generation,
+					fmt.Sprintf("NetworkFence ManifestWork creation failed: %v", err))
+
+				return true, fmt.Errorf("failed to create the NetworkFence MW on cluster %s to fence %s: %w",
+					peerCluster.Name, u.object.Name, err)
+			}
+		}
+
+		setDRClusterFencingCondition(&u.object.Status.Conditions, u.object.Generation,
+			"ManifestWork for NetworkFence fence operation created")
+		u.setDRClusterPhase(ramen.Fencing)
+		// just created fencing resources. Requeue and then check.
+		return true, nil
+	}
+
+	// Already fencing, check ALL NetworkFence statuses
 	for _, nfClass := range nfClasses {
-		reque, err := u.fenceClusterOnCluster(&peerCluster, nfClass)
+		err := u.checkFenceStatus(&peerCluster, nfClass)
 		if err != nil {
-			return reque, err
+			return true, err
 		}
 	}
+
+	// All NetworkFences succeeded
+	setDRClusterFencedCondition(&u.object.Status.Conditions, u.object.Generation,
+		"Cluster successfully fenced")
+	u.advanceToNextPhase()
 
 	return false, nil
 }
@@ -1058,44 +1085,9 @@ func (u *drclusterInstance) clusterUnfence() (bool, error) {
 	return u.cleanClusters([]ramen.DRCluster{*u.object, peerCluster})
 }
 
-// if the fencing CR (via MCV) exists; then
-//
-//	if the status of fencing CR shows fenced
-//	   return dontRequeue, nil
-//	else
-//	   return requeue, error
-//	endif
-//
-// else
-//
-//	Create the fencing CR MW with Fenced state
-//	return requeue, nil
-//
-// endif
-func (u *drclusterInstance) fenceClusterOnCluster(peerCluster *ramen.DRCluster,
+func (u *drclusterInstance) checkFenceStatus(peerCluster *ramen.DRCluster,
 	networkFenceClassName string,
-) (bool, error) {
-	if !u.isFencingOrFenced() {
-		u.log.Info(fmt.Sprintf("initiating the cluster fence from the cluster %s", peerCluster.Name))
-
-		if err := u.createNFManifestWork(u.object, peerCluster, u.log, networkFenceClassName); err != nil {
-			setDRClusterFencingFailedCondition(&u.object.Status.Conditions, u.object.Generation,
-				fmt.Sprintf("NetworkFence ManifestWork creation failed: %v", err))
-
-			u.log.Info(fmt.Sprintf("Failed to generate NetworkFence MW on cluster %s to unfence %s",
-				peerCluster.Name, u.object.Name))
-
-			return true, fmt.Errorf("failed to create the NetworkFence MW on cluster %s to fence %s: %w",
-				peerCluster.Name, u.object.Name, err)
-		}
-
-		setDRClusterFencingCondition(&u.object.Status.Conditions, u.object.Generation,
-			"ManifestWork for NetworkFence fence operation created")
-		u.setDRClusterPhase(ramen.Fencing)
-		// just created fencing resource. Requeue and then check.
-		return true, nil
-	}
-
+) error {
 	annotations := make(map[string]string)
 	annotations[DRClusterNameAnnotation] = u.object.Name
 
@@ -1107,11 +1099,11 @@ func (u *drclusterInstance) fenceClusterOnCluster(peerCluster *ramen.DRCluster,
 		// created in the manged cluster or MCV for it might not have been
 		// created yet. This assumption is because, drCluster does not delete
 		// the NetworkFence resource as part of fencing.
-		return true, fmt.Errorf("failed to get NetworkFence using MCV (error: %w)", err)
+		return fmt.Errorf("failed to get NetworkFence using MCV (error: %w)", err)
 	}
 
 	if nf.Spec.FenceState != csiaddonsv1alpha1.FenceState(u.object.Spec.ClusterFence) {
-		return true, fmt.Errorf("fence state in the NetworkFence resource is not changed to %v yet",
+		return fmt.Errorf("fence state in the NetworkFence resource is not changed to %v yet",
 			u.object.Spec.ClusterFence)
 	}
 
@@ -1121,14 +1113,10 @@ func (u *drclusterInstance) fenceClusterOnCluster(peerCluster *ramen.DRCluster,
 
 		u.log.Info("Fencing operation not successful", "cluster", u.object.Name)
 
-		return true, fmt.Errorf("fencing operation result not successful")
+		return fmt.Errorf("fencing operation result not successful")
 	}
 
-	setDRClusterFencedCondition(&u.object.Status.Conditions, u.object.Generation,
-		"Cluster successfully fenced")
-	u.advanceToNextPhase()
-
-	return false, nil
+	return nil
 }
 
 // if the fencing CR (via MCV) exist; then

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -425,6 +425,11 @@ func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.R
 
 	drclusterMetrics := createDRClusterMetricsInstance(u.object)
 
+	requeue, err = u.clusterFenceHandle()
+	if err != nil {
+		u.log.Info("Error during processing fencing", "error", err)
+	}
+
 	if reason, err := validateS3Profile(u.ctx, r.APIReader, r.ObjectStoreGetter, u.object, u.namespacedName.String(),
 		u.log); err != nil {
 		return ctrl.Result{}, fmt.Errorf("drclusters s3Profile validate: %w", u.validatedSetFalseAndUpdate(reason, err))
@@ -445,11 +450,6 @@ func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.R
 	if err = u.validateCIDRs(drclusterMetrics.InvalidCIDRsDetectedMetrics, u.log); err != nil {
 		return ctrl.Result{}, fmt.Errorf("drclusters CIDRs validate: %w",
 			u.validatedSetFalseAndUpdate(ReasonValidationFailed, err))
-	}
-
-	requeue, err = u.clusterFenceHandle()
-	if err != nil {
-		u.log.Info("Error during processing fencing", "error", err)
 	}
 
 	setDRClusterValidatedCondition(&u.object.Status.Conditions, u.object.Generation, "Validated the cluster")

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -5,6 +5,7 @@ package controllers_test
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -26,7 +27,7 @@ import (
 	"github.com/ramendr/ramen/internal/controller/util"
 )
 
-var NFClassAvailable bool
+var NFClassCount int // Number of NFCs to simulate (0=disabled, 1=single, 2+=multiple)
 
 var cidrs = [][]string{
 	{"198.51.100.17/24", "198.51.100.18/24", "198.51.100.19/24"}, // valid CIDR
@@ -77,7 +78,16 @@ var baseDRCConfig = &ramen.DRClusterConfig{
 func generateDRCC() *ramen.DRClusterConfig {
 	drcc := baseDRCConfig.DeepCopy()
 	drcc.Status.StorageClasses = []string{"sc1"}
-	drcc.Status.NetworkFenceClasses = []string{"nfc1"}
+
+	// Support multiple NFCs for testing
+	nfClasses := make([]string, NFClassCount)
+
+	for i := 0; i < NFClassCount; i++ {
+		nfClasses[i] = fmt.Sprintf("nfc%d", i+1)
+	}
+
+	drcc.Status.NetworkFenceClasses = nfClasses
+
 	drcc.Status.StorageAccessDetails = []ramen.StorageAccessDetail{
 		{
 			StorageProvisioner: "fake.ramen.com",
@@ -99,9 +109,9 @@ func generateSC() *storagev1.StorageClass {
 	return sc
 }
 
-func generateNFC() *csiaddonsv1alpha1.NetworkFenceClass {
+func generateNFCByName(name string) *csiaddonsv1alpha1.NetworkFenceClass {
 	nfc := baseNFClass.DeepCopy()
-	nfc.Name = "nfc1"
+	nfc.Name = name
 	nfc.Annotations = map[string]string{
 		controllers.StorageIDLabel: "sc1-sid",
 	}
@@ -131,7 +141,7 @@ func (f FakeMCVGetter) GetNFFromManagedCluster(resourceName, networkFenceClass, 
 
 	nf.Generation = 1
 
-	if NFClassAvailable {
+	if NFClassCount > 0 {
 		nf.Name = strings.Join([]string{controllers.NetworkFencePrefix, "drc-cluster0", "nfc1"}, "-")
 		nf.Spec.NetworkFenceClassName = "nfc1"
 	}
@@ -143,8 +153,9 @@ func (f FakeMCVGetter) GetNFClassFromManagedCluster(resourceName, managedCluster
 ) (*csiaddonsv1alpha1.NetworkFenceClass, error) {
 	// Guard against test interference: Only return populated NetworkFenceClass when
 	// NFClass is being tested to maintain test isolation for other test suites.
-	if NFClassAvailable {
-		return generateNFC(), nil
+	if NFClassCount > 0 {
+		// Return the NFC matching the requested resourceName
+		return generateNFCByName(resourceName), nil
 	}
 
 	return nil, nil
@@ -156,7 +167,7 @@ func (f FakeMCVGetter) GetDRClusterConfigFromManagedCluster(
 ) (*ramen.DRClusterConfig, error) {
 	// Guard against test interference: Only return populated DRClusterConfig when
 	// NFClass is being tested to maintain test isolation for other test suites.
-	if NFClassAvailable {
+	if NFClassCount > 0 {
 		return generateDRCC(), nil
 	}
 
@@ -167,7 +178,7 @@ func (f FakeMCVGetter) GetSClassFromManagedCluster(resourceName, managedCluster 
 ) (*storagev1.StorageClass, error) {
 	// Guard against test interference: Only return populated StorageClass when
 	// NFClass is being tested to maintain test isolation for other test suites.
-	if NFClassAvailable {
+	if NFClassCount > 0 {
 		return generateSC(), nil
 	}
 
@@ -997,9 +1008,9 @@ var _ = Describe("DRClusterController", func() {
 
 		When("provided Fencing value is Fenced where NFClass is available", func() {
 			It("should update NetworkFence correctly with NetworkFenceClass Name", func() {
-				NFClassAvailable = true
+				NFClassCount = 1
 
-				defer func() { NFClassAvailable = false }()
+				defer func() { NFClassCount = 0 }()
 
 				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateFenced
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
@@ -1020,9 +1031,9 @@ var _ = Describe("DRClusterController", func() {
 
 		When("provided Fencing value is Unfenced where NFClass is available", func() {
 			It("reports validated with status fencing as Unfenced", func() {
-				NFClassAvailable = true
+				NFClassCount = 1
 
-				defer func() { NFClassAvailable = false }()
+				defer func() { NFClassCount = 0 }()
 
 				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateUnfenced
 				drcluster = updateDRClusterParameters(drcluster)
@@ -1041,6 +1052,50 @@ var _ = Describe("DRClusterController", func() {
 				)
 			})
 		})
+
+		When("provided Fencing value with Multiple NFClasses", func() {
+			It("creates, checks, and cleans up all NetworkFence ManifestWorks", func() {
+				NFClassCount = 2
+
+				defer func() {
+					NFClassCount = 0
+				}()
+
+				// Fence the cluster
+				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateFenced
+				drcluster = updateDRClusterParameters(drcluster)
+				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
+				// Verify fencing succeeds
+				objectConditionExpectEventually(
+					apiReader,
+					drcluster,
+					metav1.ConditionTrue,
+					Equal(controllers.DRClusterConditionReasonFenced),
+					Ignore(),
+					ramen.DRClusterConditionTypeFenced,
+					false,
+				)
+
+				// Unfence the cluster
+				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateUnfenced
+				drcluster = updateDRClusterParameters(drcluster)
+
+				// Verify unfencing and cleanup succeeds (Clean state means all MWs deleted)
+				objectConditionExpectEventually(
+					apiReader,
+					drcluster,
+					metav1.ConditionFalse,
+					BeElementOf(controllers.DRClusterConditionReasonUnfenced, controllers.DRClusterConditionReasonCleaning,
+						controllers.DRClusterConditionReasonClean),
+					Ignore(),
+					ramen.DRClusterConditionTypeFenced,
+					false,
+				)
+			})
+		})
+
 		When("provided Fencing value is empty", func() {
 			It("reports validated with status fencing as Unfenced", func() {
 				drcluster.Spec.ClusterFence = ""
@@ -1083,9 +1138,9 @@ var _ = Describe("DRClusterController", func() {
 
 		When("provided CIDRs match detected StorageAccessDetails", func() {
 			It("reports validated with reason Succeeded", func() {
-				NFClassAvailable = true
+				NFClassCount = 1
 
-				defer func() { NFClassAvailable = false }()
+				defer func() { NFClassCount = 0 }()
 
 				drcluster.Spec.CIDRs = cidrs[0]
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
@@ -1106,9 +1161,9 @@ var _ = Describe("DRClusterController", func() {
 
 		When("provided CIDRs do not match detected StorageAccessDetails", func() {
 			It("reports NOT validated with reason ValidationFailed", func() {
-				NFClassAvailable = true
+				NFClassCount = 1
 
-				defer func() { NFClassAvailable = false }()
+				defer func() { NFClassCount = 0 }()
 
 				drcluster.Spec.CIDRs = []string{"192.168.1.0/24"} // CIDR not in StorageAccessDetails
 				drcluster = updateDRClusterParameters(drcluster)

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -411,19 +411,18 @@ var _ = Describe("DRClusterController", func() {
 				)
 			})
 		})
-		When("fenced with invalid S3Profile", func() {
-			It("reports NOT validated with reason s3ListFailed and does not process fencing", func() {
-				By("updating DRCluster to ManuallyFenced with an invalid S3Profile")
-
+		When("fenced", func() {
+			It("reports validated with reason Succeeded and ignores S3Profile errors", func() {
+				By("fencing an existing DRCluster with an invalid S3Profile")
 				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateManuallyFenced
 				drcluster = updateDRClusterParameters(drcluster)
 				objectConditionExpectEventually(
 					apiReader,
 					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ListFailed"),
+					metav1.ConditionTrue,
+					Equal(controllers.DRClusterConditionReasonFenced),
 					Ignore(),
-					ramen.DRClusterValidated,
+					ramen.DRClusterConditionTypeFenced,
 					false,
 				)
 			})
@@ -777,8 +776,8 @@ var _ = Describe("DRClusterController", func() {
 			drcluster = drclusters[0].DeepCopy()
 		})
 
-		When("provided fencing value is Fenced with invalid S3Profile", func() {
-			It("reports NOT validated with reason s3ListFailed and does not process fencing", func() {
+		When("provided Fencing value is Fenced and the s3 validation fails", func() {
+			It("reports fenced with reason Fencing success but validated condition should be false", func() {
 				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateFenced
 				drcluster.Spec.S3ProfileName = s3Profiles[4].S3ProfileName
 				Expect(k8sClient.Create(context.TODO(), drcluster)).To(Succeed())
@@ -786,10 +785,10 @@ var _ = Describe("DRClusterController", func() {
 				objectConditionExpectEventually(
 					apiReader,
 					drcluster,
-					metav1.ConditionFalse,
-					Equal("s3ListFailed"),
+					metav1.ConditionTrue,
+					Equal(controllers.DRClusterConditionReasonFenced),
 					Ignore(),
-					ramen.DRClusterValidated,
+					ramen.DRClusterConditionTypeFenced,
 					false,
 				)
 			})
@@ -800,16 +799,16 @@ var _ = Describe("DRClusterController", func() {
 		// we need to remove the change the fenced status to "", so that ramen will not
 		// look for the peer cluster in this situtaion
 		When("provided Fencing value is empty", func() {
-			It("reports NOT validated with reason s3ListFailed and fencing is cleared", func() {
+			It("reports validated with status fencing as Unfenced", func() {
 				drcluster.Spec.ClusterFence = ""
 				drcluster = updateDRClusterParameters(drcluster)
 				objectConditionExpectEventually(
 					apiReader,
 					drcluster,
 					metav1.ConditionFalse,
-					Equal("s3ListFailed"),
+					Equal(controllers.DRClusterConditionReasonClean),
 					Ignore(),
-					ramen.DRClusterValidated,
+					ramen.DRClusterConditionTypeFenced,
 					false,
 				)
 			})

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -120,9 +120,10 @@ func (f FakeMCVGetter) GetNFFromManagedCluster(resourceName, networkFenceClass, 
 	nf := baseNF.DeepCopy()
 
 	callerName := getFunctionNameAtIndex(2)
-	if callerName == "fenceClusterOnCluster" {
+	switch callerName {
+	case "checkFenceStatus":
 		nf.Spec.FenceState = csiaddonsv1alpha1.Fenced
-	} else if callerName == "unfenceClusterOnCluster" {
+	case "checkUnfenceStatus":
 		nf.Spec.FenceState = csiaddonsv1alpha1.Unfenced
 	}
 
@@ -414,6 +415,7 @@ var _ = Describe("DRClusterController", func() {
 		When("fenced", func() {
 			It("reports validated with reason Succeeded and ignores S3Profile errors", func() {
 				By("fencing an existing DRCluster with an invalid S3Profile")
+
 				drcluster.Spec.ClusterFence = ramen.ClusterFenceStateManuallyFenced
 				drcluster = updateDRClusterParameters(drcluster)
 				objectConditionExpectEventually(


### PR DESCRIPTION
This PR Fixes critical bugs in the DRCluster fencing workflow when multiple NetworkFenceClasses (NFCs) are configured:

Fencing getting stuck when S3 validation fails
Only the first NFC being processed during fencing operations
Only the first NFC being processed during unfencing operations
NetworkFence ManifestWorks not being cleaned up for multiple NFCs
Adds test coverage for multiple NFC scenarios

upstream PR ref: https://github.com/RamenDR/ramen/pull/2525