### PR TITLE
DFBUGS-6534: Fix metrics service and alerts.yaml

### DIFF
--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -71,4 +71,4 @@ spec:
             severity: critical
           annotations:
             description: "DRPC '{{ $labels.obj_name }}' in namespace '{{ $labels.obj_namespace }}' requires manual cleanup. Check DRPC status for details."
-          alert_type: "DisasterRecovery"
+            alert_type: "DisasterRecovery"

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - name: https
     port: 8443
-    targetPort: 8443
+    targetPort: 9289
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
## Description
- This PR fixes YAML indentation issues in the alert configuration files.
- Fix Prometheus scrape failures for Ramen metrics by updating the metrics Service to forward to the controller‑runtime metrics endpoint.

#### Observation
Prometheus targets for Ramen metrics were reported as DOWN with connection refused while scraping :8443/metrics, even after fixing YAML indentation issues in alerts.

#### Root cause
Recent Ramen changes moved metrics to the controller‑runtime metrics server, which listens on container port 9289. The existing metrics Service still forwarded to 8443, a port that is no longer used.

## Changes
- Fixed indentation in config/prometheus/alerts.yaml
- Update ramen-hub-operator-metrics-service to forward traffic to targetPort: 9289
   Keep the Service port name unchanged so the existing ServiceMonitor continues to work
   
#### Result
Prometheus can successfully scrape Ramen metrics via the updated Service without any changes to Ramen code or the ServiceMonitor.
