### PR TITLE
DFBUGS-6764: Fix PVC leftover issue for non-discovered apps

### DIFF
--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -3188,9 +3188,17 @@ func (v *VSHandler) checkLastSnapshotSyncStatus(lrs *volsyncv1alpha1.Replication
 }
 
 func (v *VSHandler) DisownVolSyncManagedPVC(pvc *corev1.PersistentVolumeClaim) error {
-	// TODO: Remove just the VRG ownerReference instead of blindly removing all ownerreferences.
-	// For now, this is fine, given that the VRG is the sole owner of the PVC after DR is enabled.
-	pvc.ObjectMeta.OwnerReferences = nil
+	// Remove only the VRG ownerReference, keeping VolSync resource (RS/RD) ownership
+	// This allows Kubernetes garbage collection to properly clean up PVCs when VolSync resources are deleted
+	newRefs := []metav1.OwnerReference{}
+
+	for _, ref := range pvc.OwnerReferences {
+		if ref.Kind != "VolumeReplicationGroup" {
+			newRefs = append(newRefs, ref)
+		}
+	}
+
+	pvc.ObjectMeta.OwnerReferences = newRefs
 	delete(pvc.Annotations, ACMAppSubDoNotDeleteAnnotation)
 
 	return v.client.Update(v.ctx, pvc)


### PR DESCRIPTION
During VRG deletion, DisownVolSyncManagedPVC was removing all ownerReferences from PVCs instead of just the VRG owner. This conflicted with the skipPVCDisownership=true flag used during cleanup, breaking Kubernetes garbage collection for non-discovered apps that have the
do-not-delete-pvc annotation.

The PVC should have two owners: VRG and VolSync resource (RS/RD). PR #2242 correctly preserves RS/RD ownership during cleanup via skipPVCDisownership=true. However, DisownVolSyncManagedPVC() was removing all owners when the annotation is present, undermining this protection.

This fix makes DisownVolSyncManagedPVC() remove only the VRG ownerReference, aligning with skipPVCDisownership=true and allowing Kubernetes garbage collection to properly clean up PVCs when VolSync resources are deleted.

This resolves PVC leftover issues in three scenarios:
- Failover followed by application deletion
- Relocate followed by application deletion
- Direct application deletion after DR enablement

Fixes: [DFBUGS-2828](https://redhat.atlassian.net/browse/DFBUGS-2828)
Related: PR RamenDR#2504, PR RamenDR#2242