### PR TITLE
DFBUGS-6409: Apply dr-cluster OLM settings from hub Subscription

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	recipe "github.com/ramendr/recipe/api/v1alpha1"
 	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	plrv1 "github.com/stolostron/multicloud-operators-placementrule/pkg/apis/apps/v1"
@@ -105,6 +106,7 @@ func configureController() error {
 	setupLog.Info("controller type", "type", controllers.ControllerType)
 
 	if controllers.ControllerType == ramendrv1alpha1.DRHubType {
+		utilruntime.Must(operatorsv1alpha1.AddToScheme(scheme))
 		utilruntime.Must(plrv1.AddToScheme(scheme))
 		utilruntime.Must(ocmworkv1.AddToScheme(scheme))
 		utilruntime.Must(viewv1beta1.AddToScheme(scheme))

--- a/config/hub/rbac/role.yaml
+++ b/config/hub/rbac/role.yaml
@@ -148,6 +148,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ramendr.openshift.io
   resources:
   - drclusters

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -8,8 +8,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,6 +49,8 @@ const (
 	VeleroNamespaceNameDefault                        = "velero"
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 	defaultMaxConcurrentReconciles                    = 50
+	openshiftOperatorsNamespace                       = "openshift-operators"
+	openshiftDRSystemNamespace                        = "openshift-dr-system"
 )
 
 // FIXME
@@ -88,9 +92,6 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 		VolumeUnprotectionEnabled: true,
 	}
 
-	cfg.DrClusterOperator.ChannelName = drClusterOperatorChannelNameDefault
-	cfg.DrClusterOperator.PackageName = drClusterOperatorPackageNameDefault
-	cfg.DrClusterOperator.CatalogSourceName = drClusterOperatorCatalogSourceNameDefault
 	cfg.DrClusterOperator.DeploymentAutomationEnabled = true
 	cfg.DrClusterOperator.S3SecretDistributionEnabled = true
 
@@ -243,6 +244,26 @@ func ramenOperatorConfigMapName() string {
 	}
 }
 
+func copyDrClusterOperatorSubscriptionFields(dst, src *ramendrv1alpha1.RamenConfig) {
+	// In-memory src carries the hub subscription overlay (or compiled defaults).
+	// Re-apply onto dst after user YAML merge. DR-cluster controllers skip this:
+	// ConfigMap content comes from the hub via ManifestWork and must not be
+	// replaced with local defaults.
+	if ControllerType != ramendrv1alpha1.DRHubType || dst == nil || src == nil {
+		return
+	}
+
+	s := src.DrClusterOperator
+	d := &dst.DrClusterOperator
+
+	d.ChannelName = s.ChannelName
+	d.PackageName = s.PackageName
+	d.NamespaceName = s.NamespaceName
+	d.CatalogSourceName = s.CatalogSourceName
+	d.CatalogSourceNamespaceName = s.CatalogSourceNamespaceName
+	d.ClusterServiceVersionName = s.ClusterServiceVersionName
+}
+
 func CreateOrUpdateConfigMap(
 	ctx context.Context,
 	c client.Client,
@@ -261,6 +282,8 @@ func CreateOrUpdateConfigMap(
 		Namespace: RamenOperatorNamespace(),
 		Name:      configMapName,
 	}
+
+	updateDrClusterOperatorFromSubscription(ctx, r, defaultRamenConfig, log)
 
 	if err := r.Get(ctx, key, configMap); err != nil {
 		if !k8serrors.IsNotFound(err) {
@@ -281,6 +304,8 @@ func CreateOrUpdateConfigMap(
 	if err != nil {
 		return nil, err
 	}
+
+	copyDrClusterOperatorSubscriptionFields(&merged, defaultRamenConfig)
 
 	return configMapUpdate(ctx, c, configMap, &merged, log)
 }
@@ -386,6 +411,70 @@ func ConfigMapGet(
 
 func RamenOperatorNamespace() string {
 	return os.Getenv("POD_NAMESPACE")
+}
+
+func findHubOperatorSubscription(ctx context.Context, apiReader client.Reader,
+	log logr.Logger,
+) *operatorsv1alpha1.Subscription {
+	const hubOperatorSuffix = "-hub-operator"
+
+	ns := RamenOperatorNamespace()
+
+	subList := &operatorsv1alpha1.SubscriptionList{}
+	if err := apiReader.List(ctx, subList, client.InNamespace(ns)); err != nil {
+		log.Info("list operators.coreos.com subscriptions; continuing without hub subscription",
+			"namespace", ns, "error", err)
+
+		return nil
+	}
+
+	for i := range subList.Items {
+		sub := &subList.Items[i]
+		if sub.Spec != nil && strings.HasSuffix(sub.Spec.Package, hubOperatorSuffix) {
+			return sub
+		}
+	}
+
+	return nil
+}
+
+func applyDrClusterOperatorFromSubscriptionSpec(
+	spec *operatorsv1alpha1.SubscriptionSpec,
+	cfg *ramendrv1alpha1.RamenConfig,
+) {
+	const (
+		hubSubstring     = "-hub-"
+		clusterSubstring = "-cluster-"
+	)
+
+	dco := &cfg.DrClusterOperator
+
+	dco.ChannelName = spec.Channel
+	dco.PackageName = strings.Replace(spec.Package, hubSubstring, clusterSubstring, 1)
+	dco.CatalogSourceName = spec.CatalogSource
+	dco.CatalogSourceNamespaceName = spec.CatalogSourceNamespace
+	dco.ClusterServiceVersionName = strings.Replace(spec.StartingCSV, hubSubstring, clusterSubstring, 1)
+}
+
+func updateDrClusterOperatorFromSubscription(ctx context.Context, apiReader client.Reader,
+	cfg *ramendrv1alpha1.RamenConfig,
+	log logr.Logger,
+) {
+	if ControllerType != ramendrv1alpha1.DRHubType || cfg == nil {
+		return
+	}
+
+	sub := findHubOperatorSubscription(ctx, apiReader, log)
+
+	if sub == nil || sub.Spec == nil {
+		return
+	}
+
+	applyDrClusterOperatorFromSubscriptionSpec(sub.Spec, cfg)
+
+	if sub.Namespace == openshiftOperatorsNamespace {
+		cfg.DrClusterOperator.NamespaceName = openshiftDRSystemNamespace
+	}
 }
 
 func RamenOperandsNamespace(config ramendrv1alpha1.RamenConfig) string {

--- a/ramendev/ramendev/resources/configmap.yaml
+++ b/ramendev/ramendev/resources/configmap.yaml
@@ -25,12 +25,6 @@ data:
     drClusterOperator:
       deploymentAutomationEnabled: $auto_deploy
       s3SecretDistributionEnabled: true
-      channelName: alpha
-      packageName: ramen-dr-cluster-operator
-      namespaceName: ramen-system
-      catalogSourceName: ramen-catalog
-      catalogSourceNamespaceName: ramen-system
-      clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
     kubeObjectProtection:
       veleroNamespaceName: velero
     volSync:


### PR DESCRIPTION
- Fill empty DrClusterOperator fields from the hub operator Subscription (channel, package/catalog via -hub-/-cluster- replace, CSV) of, if Subscription does not exist - with defaults.
- Register OLM v1alpha1 types in the hub manager scheme; RBAC list/get/watch on subscriptions.
- Drop default channel/package/catalog from DefaultRamenConfig; reconcile applies the same overlay after ConfigMapGet.
- If the Subscription is in openshift-operators, set DrClusterOperator.NamespaceName to openshift-dr-system.


(cherry picked from commit 7558e0f53a2e288dab49c42a09351f1b1af74f5f)