### PR TITLE
DFBUGS-6507: ramenconfig: set Velero and RamenOps namespaces for hub

### DIFF
--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -47,10 +47,12 @@ const (
 	drClusterOperatorClusterServiceVersionNameDefault = drClusterOperatorPackageNameDefault + ".v0.0.1"
 	DefaultCephFSCSIDriverName                        = "openshift-storage.cephfs.csi.ceph.com"
 	VeleroNamespaceNameDefault                        = "velero"
+	veleroNamespaceNameDefaultOCP                     = "openshift-adp"
 	DefaultVolSyncCopyMethod                          = "Snapshot"
 	defaultMaxConcurrentReconciles                    = 50
 	openshiftOperatorsNamespace                       = "openshift-operators"
 	openshiftDRSystemNamespace                        = "openshift-dr-system"
+	openshiftDROpsNamespace                           = "openshift-dr-ops"
 )
 
 // FIXME
@@ -474,6 +476,8 @@ func updateDrClusterOperatorFromSubscription(ctx context.Context, apiReader clie
 
 	if sub.Namespace == openshiftOperatorsNamespace {
 		cfg.DrClusterOperator.NamespaceName = openshiftDRSystemNamespace
+		cfg.KubeObjectProtection.VeleroNamespaceName = veleroNamespaceNameDefaultOCP
+		cfg.RamenOpsNamespace = openshiftDROpsNamespace
 	}
 }
 


### PR DESCRIPTION
set Velero and RamenOps namespaces for hub in openshift-operators

When the hub OLM subscription lives in openshift-operators namespace, align config with the OCP layout: Velero namespace openshift-adp and Ramen ops namespace openshift-dr-ops, alongside the existing DR cluster operator install namespace.


(cherry picked from commit f28b530a43ea42cf164c7ecf10e4ba9797678e22)