### PR TITLE
DFBUGS-6042: manage excluded resources using config map

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -8,8 +8,13 @@ rules:
   - ""
   resources:
   - configmaps
+  - persistentvolumes
   verbs:
+  - create
+  - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -28,17 +33,6 @@ rules:
   verbs:
   - create
   - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - create
   - get
   - list
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -8,8 +8,13 @@ rules:
   - ""
   resources:
   - configmaps
+  - persistentvolumes
   verbs:
+  - create
+  - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -38,17 +43,6 @@ rules:
   verbs:
   - create
   - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - persistentvolumes
-  verbs:
-  - create
   - get
   - list
   - patch

--- a/internal/controller/kubeobjects/velero/exclude_resources.go
+++ b/internal/controller/kubeobjects/velero/exclude_resources.go
@@ -1,0 +1,296 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package velero
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DefaultExcludedResourcesConfigMapName is the name of the ConfigMap that contains
+	// the default list of resources to exclude from Velero backups
+	DefaultExcludedResourcesConfigMapName = "default-excluded-resources"
+
+	// ExcludedResourcesKey is the key in the ConfigMap data that contains the excluded resources list
+	ExcludedResourcesKey = "resources"
+)
+
+// getDefaultExcludedResources returns the hardcoded default list of resources to exclude from Velero backups.
+// These defaults are used when creating the ConfigMap for the first time or as a fallback.
+func getDefaultExcludedResources() []string {
+	return []string{
+		// Exclude VRs from Backup so VRG can create them: see https://github.com/RamenDR/ramen/issues/884
+		"volumereplications.replication.storage.openshift.io",
+		"volumegroupreplications.replication.storage.openshift.io",
+		// Exclude VolSync resources as they are managed by VRG
+		"replicationsources.volsync.backube",
+		"replicationdestinations.volsync.backube",
+		// Exclude PVCs and PVs as they are handled separately
+		"persistentvolumeclaims",
+		"persistentvolumes",
+		// Exclude EndpointSlices/Endpoints to prevent Submariner conflicts: see https://github.com/RamenDR/ramen/issues/1889
+		"endpointslices.discovery.k8s.io",
+		"endpoints",
+		// Exclude VolumeSnapshots and VolumeGroupSnapshots from backup
+		"volumesnapshots.snapshot.storage.k8s.io",
+		"volumegroupsnapshots.groupsnapshot.storage.k8s.io",
+	}
+}
+
+// getCriticalExcludedResources returns resources that should always be excluded
+// to prevent breaking Ramen's internal logic. These will generate warnings if removed from ConfigMap.
+func getCriticalExcludedResources() []string {
+	return []string{
+		"volumereplications.replication.storage.openshift.io",
+		"volumegroupreplications.replication.storage.openshift.io",
+		"replicationsources.volsync.backube",
+		"replicationdestinations.volsync.backube",
+	}
+}
+
+// ExcludedResourcesManager manages the default excluded resources ConfigMap
+type ExcludedResourcesManager struct {
+	client    client.Client
+	namespace string
+	log       logr.Logger
+	// Cached excluded resources list
+	cachedExclusions []string
+}
+
+// NewExcludedResourcesManager creates a new ExcludedResourcesManager
+func NewExcludedResourcesManager(client client.Client, namespace string, log logr.Logger) *ExcludedResourcesManager {
+	return &ExcludedResourcesManager{
+		client:    client,
+		namespace: namespace,
+		log:       log,
+	}
+}
+
+// EnsureConfigMap ensures the default excluded resources ConfigMap exists.
+// If it doesn't exist, it creates one with the default hardcoded values.
+// Returns the list of excluded resources.
+func (m *ExcludedResourcesManager) EnsureConfigMap(ctx context.Context) ([]string, error) {
+	configMap := &corev1.ConfigMap{}
+	configMapKey := types.NamespacedName{
+		Namespace: m.namespace,
+		Name:      DefaultExcludedResourcesConfigMapName,
+	}
+
+	err := m.client.Get(ctx, configMapKey, configMap)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("failed to get ConfigMap %s: %w", configMapKey, err)
+		}
+
+		// ConfigMap doesn't exist, create it with default values
+		m.log.Info("ConfigMap not found, creating with default excluded resources",
+			"configMap", DefaultExcludedResourcesConfigMapName,
+			"namespace", m.namespace)
+
+		configMap, err = m.createDefaultConfigMap(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create default ConfigMap: %w", err)
+		}
+	}
+
+	// Parse and return the excluded resources
+	exclusions, err := m.parseExcludedResources(configMap)
+	if err != nil {
+		m.log.Error(err, "Failed to parse excluded resources from ConfigMap, using hardcoded defaults")
+
+		return getDefaultExcludedResources(), nil
+	}
+
+	// Validate and warn about missing critical exclusions
+	m.validateCriticalExclusions(exclusions)
+
+	// Cache the exclusions
+	m.cachedExclusions = exclusions
+
+	m.log.Info("Loaded excluded resources from ConfigMap",
+		"count", len(exclusions),
+		"configMap", DefaultExcludedResourcesConfigMapName)
+
+	return exclusions, nil
+}
+
+// createDefaultConfigMap creates a ConfigMap with the default excluded resources
+func (m *ExcludedResourcesManager) createDefaultConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	defaults := getDefaultExcludedResources()
+
+	// Convert to JSON for better structure and validation
+	resourcesJSON, err := json.Marshal(defaults)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal default excluded resources: %w", err)
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultExcludedResourcesConfigMapName,
+			Namespace: m.namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":       "ramen-dr-cluster-operator",
+				"app.kubernetes.io/component":  "kubeobjects-protection",
+				"app.kubernetes.io/managed-by": "ramen-dr-cluster-operator",
+			},
+			Annotations: map[string]string{
+				"ramen.openshift.io/description": "Default list of resources to exclude from Velero backups. " +
+					"You can modify this ConfigMap to customize the exclusions. " +
+					"Changes will be picked up on the next reconciliation.",
+				"ramen.openshift.io/version": "v1",
+			},
+		},
+		Data: map[string]string{
+			ExcludedResourcesKey: string(resourcesJSON),
+		},
+	}
+
+	if err := m.client.Create(ctx, configMap); err != nil {
+		return nil, fmt.Errorf("failed to create ConfigMap: %w", err)
+	}
+
+	m.log.Info("Created default excluded resources ConfigMap",
+		"configMap", DefaultExcludedResourcesConfigMapName,
+		"namespace", m.namespace,
+		"resources", len(defaults))
+
+	return configMap, nil
+}
+
+// parseExcludedResources parses the excluded resources from the ConfigMap
+func (m *ExcludedResourcesManager) parseExcludedResources(configMap *corev1.ConfigMap) ([]string, error) {
+	resourcesData, ok := configMap.Data[ExcludedResourcesKey]
+	if !ok {
+		return nil, fmt.Errorf("ConfigMap missing key %s", ExcludedResourcesKey)
+	}
+
+	if resourcesData == "" {
+		m.log.Info("ConfigMap has empty excluded resources list")
+
+		return []string{}, nil
+	}
+
+	var exclusions []string
+
+	// Try to parse as JSON first
+	err := json.Unmarshal([]byte(resourcesData), &exclusions)
+	if err != nil {
+		// Fallback to comma-separated format for backwards compatibility
+		m.log.Info("ConfigMap data is not JSON, trying comma-separated format")
+		exclusions = m.parseCommaSeparated(resourcesData)
+	}
+
+	// Trim whitespace from all entries
+	for i := range exclusions {
+		exclusions[i] = strings.TrimSpace(exclusions[i])
+	}
+
+	// Remove empty entries
+	filtered := make([]string, 0, len(exclusions))
+	for _, resource := range exclusions {
+		if resource != "" {
+			filtered = append(filtered, resource)
+		}
+	}
+
+	return filtered, nil
+}
+
+// parseCommaSeparated parses a comma-separated list of resources
+func (m *ExcludedResourcesManager) parseCommaSeparated(data string) []string {
+	parts := strings.Split(data, ",")
+	result := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+
+	return result
+}
+
+// validateCriticalExclusions checks if critical resources are in the exclusion list
+// and logs warnings if they're missing
+func (m *ExcludedResourcesManager) validateCriticalExclusions(exclusions []string) {
+	criticalResources := getCriticalExcludedResources()
+
+	for _, critical := range criticalResources {
+		found := false
+
+		for _, excluded := range exclusions {
+			if excluded == critical {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			m.log.Info("WARNING: Critical resource not in exclusions list, this may cause issues",
+				"resource", critical,
+				"reason", "Required by Ramen for proper VRG operation")
+		}
+	}
+}
+
+// GetExcludedResources returns the cached excluded resources.
+// If not cached, it loads from ConfigMap.
+func (m *ExcludedResourcesManager) GetExcludedResources(ctx context.Context) ([]string, error) {
+	if m.cachedExclusions != nil {
+		return m.cachedExclusions, nil
+	}
+
+	return m.EnsureConfigMap(ctx)
+}
+
+// ReloadExcludedResources reloads the excluded resources from the ConfigMap.
+// This should be called when the ConfigMap is updated.
+func (m *ExcludedResourcesManager) ReloadExcludedResources(ctx context.Context) ([]string, error) {
+	m.log.Info("Reloading excluded resources from ConfigMap")
+
+	configMap := &corev1.ConfigMap{}
+	configMapKey := types.NamespacedName{
+		Namespace: m.namespace,
+		Name:      DefaultExcludedResourcesConfigMapName,
+	}
+
+	err := m.client.Get(ctx, configMapKey, configMap)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// ConfigMap was deleted, recreate with defaults
+			m.log.Info("ConfigMap was deleted, recreating with defaults")
+
+			return m.EnsureConfigMap(ctx)
+		}
+
+		return nil, fmt.Errorf("failed to reload ConfigMap: %w", err)
+	}
+
+	exclusions, err := m.parseExcludedResources(configMap)
+	if err != nil {
+		m.log.Error(err, "Failed to parse excluded resources after reload, using previous cache")
+
+		return m.cachedExclusions, nil
+	}
+
+	m.validateCriticalExclusions(exclusions)
+	m.cachedExclusions = exclusions
+
+	m.log.Info("Reloaded excluded resources from ConfigMap",
+		"count", len(exclusions))
+
+	return exclusions, nil
+}

--- a/internal/controller/kubeobjects/velero/exclude_resources_test.go
+++ b/internal/controller/kubeobjects/velero/exclude_resources_test.go
@@ -1,0 +1,503 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package velero_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/ramendr/ramen/internal/controller/kubeobjects/velero"
+)
+
+const (
+	testNamespace = "test-namespace"
+)
+
+// setupFakeClient creates a fake client with corev1 scheme
+func setupFakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	require.NoError(t, err)
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+// createConfigMapWithJSON creates a ConfigMap with JSON-formatted excluded resources
+func createConfigMapWithJSON(namespace string, resources []string) *corev1.ConfigMap {
+	resourcesJSON, err := json.Marshal(resources)
+	if err != nil {
+		return nil
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      velero.DefaultExcludedResourcesConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			velero.ExcludedResourcesKey: string(resourcesJSON),
+		},
+	}
+}
+
+// createConfigMapWithCommaSeparated creates a ConfigMap with comma-separated excluded resources
+func createConfigMapWithCommaSeparated(namespace string, resourcesStr string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      velero.DefaultExcludedResourcesConfigMapName,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			velero.ExcludedResourcesKey: resourcesStr,
+		},
+	}
+}
+
+// TestEnsureConfigMap_CreatesConfigMapWhenNotExists tests that the manager creates
+// a ConfigMap with default resources when it doesn't exist
+func TestEnsureConfigMap_CreatesConfigMapWhenNotExists(t *testing.T) {
+	fakeClient := setupFakeClient(t)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.NotEmpty(t, exclusions)
+
+	// Verify ConfigMap was created
+	configMap := &corev1.ConfigMap{}
+	configMapKey := types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      velero.DefaultExcludedResourcesConfigMapName,
+	}
+	err = fakeClient.Get(ctx, configMapKey, configMap)
+	require.NoError(t, err)
+
+	// Verify it has the expected labels and annotations
+	assert.Equal(t, "ramen-dr-cluster-operator", configMap.Labels["app.kubernetes.io/name"])
+	assert.Equal(t, "kubeobjects-protection", configMap.Labels["app.kubernetes.io/component"])
+	assert.Contains(t, configMap.Annotations["ramen.openshift.io/description"], "Default list of resources")
+
+	// Verify the data is valid JSON
+	var parsedResources []string
+
+	err = json.Unmarshal([]byte(configMap.Data[velero.ExcludedResourcesKey]), &parsedResources)
+	require.NoError(t, err)
+	assert.NotEmpty(t, parsedResources)
+
+	// Verify it includes critical resources
+	assert.Contains(t, parsedResources, "volumereplications.replication.storage.openshift.io")
+	assert.Contains(t, parsedResources, "replicationsources.volsync.backube")
+}
+
+// TestEnsureConfigMap_ReturnsExistingConfigMapData tests that the manager returns
+// existing ConfigMap data when it already exists
+func TestEnsureConfigMap_ReturnsExistingConfigMapData(t *testing.T) {
+	customResources := []string{
+		"volumereplications.replication.storage.openshift.io",
+		"customresource.example.com",
+	}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, customResources)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, customResources, exclusions)
+}
+
+// TestEnsureConfigMap_ParsesJSONFormat tests that the manager correctly parses
+// JSON-formatted excluded resources
+func TestEnsureConfigMap_ParsesJSONFormat(t *testing.T) {
+	expectedResources := []string{
+		"resource1.group.io",
+		"resource2.group.io",
+		"persistentvolumeclaims",
+	}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, expectedResources)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedResources, exclusions)
+}
+
+// TestEnsureConfigMap_ParsesCommaSeparatedFormat tests backward compatibility
+// with comma-separated format
+func TestEnsureConfigMap_ParsesCommaSeparatedFormat(t *testing.T) {
+	resourcesStr := "resource1.group.io, resource2.group.io, persistentvolumeclaims"
+	expectedResources := []string{
+		"resource1.group.io",
+		"resource2.group.io",
+		"persistentvolumeclaims",
+	}
+	existingConfigMap := createConfigMapWithCommaSeparated(testNamespace, resourcesStr)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedResources, exclusions)
+}
+
+// TestEnsureConfigMap_HandlesEmptyConfigMap tests that empty ConfigMap returns empty list
+func TestEnsureConfigMap_HandlesEmptyConfigMap(t *testing.T) {
+	existingConfigMap := createConfigMapWithJSON(testNamespace, []string{})
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.Empty(t, exclusions)
+}
+
+// TestEnsureConfigMap_HandlesWhitespaceInCommaSeparated tests that whitespace
+// is properly trimmed in comma-separated format
+func TestEnsureConfigMap_HandlesWhitespaceInCommaSeparated(t *testing.T) {
+	resourcesStr := "  resource1.group.io  ,  resource2.group.io  ,  , persistentvolumeclaims  "
+	expectedResources := []string{
+		"resource1.group.io",
+		"resource2.group.io",
+		"persistentvolumeclaims",
+	}
+	existingConfigMap := createConfigMapWithCommaSeparated(testNamespace, resourcesStr)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedResources, exclusions)
+}
+
+// TestEnsureConfigMap_HandlesMissingResourcesKey tests fallback to defaults
+// when ConfigMap exists but missing the resources key
+func TestEnsureConfigMap_HandlesMissingResourcesKey(t *testing.T) {
+	existingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      velero.DefaultExcludedResourcesConfigMapName,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"other-key": "other-value",
+		},
+	}
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	// Should not error, but fall back to defaults
+	require.NoError(t, err)
+	assert.NotEmpty(t, exclusions)
+	// Should include critical resources from defaults
+	assert.Contains(t, exclusions, "volumereplications.replication.storage.openshift.io")
+}
+
+// TestEnsureConfigMap_HandlesInvalidJSON tests fallback to comma-separated
+// when JSON parsing fails
+func TestEnsureConfigMap_HandlesInvalidJSON(t *testing.T) {
+	existingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      velero.DefaultExcludedResourcesConfigMapName,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			velero.ExcludedResourcesKey: "resource1, resource2", // Not JSON
+		},
+	}
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"resource1", "resource2"}, exclusions)
+}
+
+// TestGetExcludedResources_UsesCachedValue tests that GetExcludedResources
+// returns cached value without hitting the API
+func TestGetExcludedResources_UsesCachedValue(t *testing.T) {
+	customResources := []string{"cached-resource1", "cached-resource2"}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, customResources)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+
+	// First call to populate cache
+	exclusions1, err := manager.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, customResources, exclusions1)
+
+	// Delete the ConfigMap to ensure we're using cache
+	err = fakeClient.Delete(ctx, existingConfigMap)
+	require.NoError(t, err)
+
+	// GetExcludedResources should return cached value
+	exclusions2, err := manager.GetExcludedResources(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, customResources, exclusions2)
+}
+
+// TestGetExcludedResources_LoadsWhenNotCached tests that GetExcludedResources
+// loads from ConfigMap when cache is empty
+func TestGetExcludedResources_LoadsWhenNotCached(t *testing.T) {
+	customResources := []string{"resource1", "resource2"}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, customResources)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+
+	// Call GetExcludedResources without EnsureConfigMap first
+	exclusions, err := manager.GetExcludedResources(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, customResources, exclusions)
+}
+
+// TestReloadExcludedResources_UpdatesCache tests that ReloadExcludedResources
+// refreshes the cache from the ConfigMap
+func TestReloadExcludedResources_UpdatesCache(t *testing.T) {
+	initialResources := []string{"resource1", "resource2"}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, initialResources)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+
+	// First load
+	exclusions1, err := manager.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, initialResources, exclusions1)
+
+	// Update ConfigMap
+	updatedResources := []string{"updated-resource1", "updated-resource2", "updated-resource3"}
+
+	updatedJSON, err := json.Marshal(updatedResources)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	existingConfigMap.Data[velero.ExcludedResourcesKey] = string(updatedJSON)
+	err = fakeClient.Update(ctx, existingConfigMap)
+	require.NoError(t, err)
+
+	// Reload and verify updated resources
+	exclusions2, err := manager.ReloadExcludedResources(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, updatedResources, exclusions2)
+
+	// Verify cache was updated
+	exclusions3, err := manager.GetExcludedResources(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, updatedResources, exclusions3)
+}
+
+// TestReloadExcludedResources_RecreatesDeletedConfigMap tests that
+// ReloadExcludedResources recreates ConfigMap if it was deleted
+func TestReloadExcludedResources_RecreatesDeletedConfigMap(t *testing.T) {
+	initialResources := []string{"resource1", "resource2"}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, initialResources)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+
+	// First load
+	exclusions1, err := manager.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, initialResources, exclusions1)
+
+	// Delete ConfigMap
+	err = fakeClient.Delete(ctx, existingConfigMap)
+	require.NoError(t, err)
+
+	// Verify ConfigMap is deleted
+	configMapKey := types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      velero.DefaultExcludedResourcesConfigMapName,
+	}
+	err = fakeClient.Get(ctx, configMapKey, &corev1.ConfigMap{})
+	assert.True(t, errors.IsNotFound(err))
+
+	// Reload should recreate with defaults
+	exclusions2, err := manager.ReloadExcludedResources(ctx)
+	require.NoError(t, err)
+	assert.NotEmpty(t, exclusions2)
+
+	// Verify ConfigMap was recreated
+	recreatedConfigMap := &corev1.ConfigMap{}
+	err = fakeClient.Get(ctx, configMapKey, recreatedConfigMap)
+	require.NoError(t, err)
+	assert.NotNil(t, recreatedConfigMap)
+}
+
+// TestReloadExcludedResources_FallbackOnParseError tests that ReloadExcludedResources
+// falls back to cached value when parse error occurs
+func TestReloadExcludedResources_FallbackOnParseError(t *testing.T) {
+	initialResources := []string{"resource1", "resource2"}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, initialResources)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+
+	// First load to populate cache
+	exclusions1, err := manager.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, initialResources, exclusions1)
+
+	// Update ConfigMap to remove the resources key (will cause parse error)
+	existingConfigMap.Data = map[string]string{
+		"wrong-key": "wrong-value",
+	}
+	err = fakeClient.Update(ctx, existingConfigMap)
+	require.NoError(t, err)
+
+	// Reload should return cached value on parse error
+	exclusions2, err := manager.ReloadExcludedResources(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, initialResources, exclusions2)
+}
+
+// TestEnsureConfigMap_ValidatesCriticalResources tests that missing critical
+// resources are logged (warning behavior)
+func TestEnsureConfigMap_ValidatesCriticalResources(t *testing.T) {
+	// ConfigMap without critical resources
+	resourcesWithoutCritical := []string{
+		"persistentvolumeclaims",
+		"persistentvolumes",
+	}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, resourcesWithoutCritical)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+
+	// This should succeed but log warnings
+	exclusions, err := manager.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, resourcesWithoutCritical, exclusions)
+	// Note: We can't easily test log output without a custom logger,
+	// but at least verify it doesn't error out
+}
+
+// TestEnsureConfigMap_ConfigMapWithCriticalResources tests that all critical
+// resources are properly recognized
+func TestEnsureConfigMap_ConfigMapWithCriticalResources(t *testing.T) {
+	resourcesWithCritical := []string{
+		"volumereplications.replication.storage.openshift.io",
+		"volumegroupreplications.replication.storage.openshift.io",
+		"replicationsources.volsync.backube",
+		"replicationdestinations.volsync.backube",
+		"persistentvolumeclaims",
+	}
+	existingConfigMap := createConfigMapWithJSON(testNamespace, resourcesWithCritical)
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+
+	exclusions, err := manager.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, resourcesWithCritical, exclusions)
+	// All critical resources are present, so no warnings
+}
+
+// TestEnsureConfigMap_MultipleNamespaces tests that managers with different
+// namespaces operate independently
+func TestEnsureConfigMap_MultipleNamespaces(t *testing.T) {
+	namespace1 := "namespace1"
+	namespace2 := "namespace2"
+
+	resources1 := []string{"resource1"}
+	resources2 := []string{"resource2"}
+
+	configMap1 := createConfigMapWithJSON(namespace1, resources1)
+	configMap2 := createConfigMapWithJSON(namespace2, resources2)
+
+	fakeClient := setupFakeClient(t, configMap1, configMap2)
+	logger := zap.New(zap.UseDevMode(true))
+
+	manager1 := velero.NewExcludedResourcesManager(fakeClient, namespace1, logger)
+	manager2 := velero.NewExcludedResourcesManager(fakeClient, namespace2, logger)
+
+	ctx := context.Background()
+
+	exclusions1, err := manager1.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, resources1, exclusions1)
+
+	exclusions2, err := manager2.EnsureConfigMap(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, resources2, exclusions2)
+}
+
+// TestParseExcludedResources_FiltersEmptyEntries tests that empty entries
+// from JSON arrays are filtered out
+func TestParseExcludedResources_FiltersEmptyEntries(t *testing.T) {
+	// JSON with empty strings
+	resourcesJSON := `["resource1", "", "resource2", "  ", "resource3"]`
+	existingConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      velero.DefaultExcludedResourcesConfigMapName,
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			velero.ExcludedResourcesKey: resourcesJSON,
+		},
+	}
+	fakeClient := setupFakeClient(t, existingConfigMap)
+	logger := zap.New(zap.UseDevMode(true))
+	manager := velero.NewExcludedResourcesManager(fakeClient, testNamespace, logger)
+
+	ctx := context.Background()
+	exclusions, err := manager.EnsureConfigMap(ctx)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"resource1", "resource2", "resource3"}, exclusions)
+}

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -435,14 +435,13 @@ func getBackupSpecFromObjectsSpec(objectsSpec kubeobjects.Spec) velero.BackupSpe
 	return velero.BackupSpec{
 		IncludedNamespaces: objectsSpec.IncludedNamespaces,
 		IncludedResources:  objectsSpec.IncludedResources,
-		// exclude VRs from Backup so VRG can create them: see https://github.com/RamenDR/ramen/issues/884
-		// exclude EndpointSlices/Endpoints to prevent Submariner conflicts: see https://github.com/RamenDR/ramen/issues/1889
-		// exclude VolumeSnapshots and VolumeGroupSnapshots from backup
-		ExcludedResources: append(objectsSpec.ExcludedResources, "volumereplications.replication.storage.openshift.io",
-			"volumegroupreplications.replication.storage.openshift.io", "replicationsources.volsync.backube",
-			"replicationdestinations.volsync.backube", "PersistentVolumeClaims", "PersistentVolumes",
-			"endpointslices.discovery.k8s.io", "endpoints", "volumesnapshots.snapshot.storage.k8s.io",
-			"volumegroupsnapshots.groupsnapshot.storage.k8s.io"),
+		// ExcludedResources are now managed via the default-excluded-resources ConfigMap
+		// and merged with recipe-level exclusions in vrg_kubeobjects.go
+		// The objectsSpec.ExcludedResources already contains the merged list:
+		// - Default exclusions from ConfigMap (bootstrapped with hardcoded defaults if not present)
+		// - Recipe group-level exclusions
+		// See: internal/controller/exclude_resources.go and vrg_kubeobjects.go:mergeExcludedResources()
+		ExcludedResources:       objectsSpec.ExcludedResources,
 		LabelSelector:           newLabelSelector,
 		OrLabelSelectors:        objectsSpec.OrLabelSelectors,
 		TTL:                     metav1.Duration{}, // TODO: set default here

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -51,15 +51,18 @@ import (
 // VolumeReplicationGroupReconciler reconciles a VolumeReplicationGroup object
 type VolumeReplicationGroupReconciler struct {
 	client.Client
-	APIReader           client.Reader
-	Log                 logr.Logger
-	ObjStoreGetter      ObjectStoreGetter
-	Scheme              *runtime.Scheme
-	eventRecorder       *util.EventReporter
-	kubeObjects         kubeobjects.RequestsManager
-	RateLimiter         *workqueue.TypedRateLimiter[reconcile.Request]
-	veleroCRsAreWatched bool
-	recipeRetries       sync.Map
+	APIReader               client.Reader
+	Log                     logr.Logger
+	ObjStoreGetter          ObjectStoreGetter
+	Scheme                  *runtime.Scheme
+	eventRecorder           *util.EventReporter
+	kubeObjects             kubeobjects.RequestsManager
+	RateLimiter             *workqueue.TypedRateLimiter[reconcile.Request]
+	veleroCRsAreWatched     bool
+	recipeRetries           sync.Map
+	excludedResourcesMgr    *velero.ExcludedResourcesManager
+	excludedResourcesMutex  sync.RWMutex
+	cachedExcludedResources []string
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -123,6 +126,13 @@ func (r *VolumeReplicationGroupReconciler) SetupWithManager(
 
 	if !ramenConfig.KubeObjectProtection.Disabled {
 		ctrlBuilder = r.addKubeObjectsOwnsAndWatches(ctrlBuilder)
+
+		// Initialize the excluded resources manager for kube object protection
+		r.excludedResourcesMgr = velero.NewExcludedResourcesManager(
+			r.Client,
+			RamenOperatorNamespace(),
+			r.Log.WithName("excluded-resources"),
+		)
 	} else {
 		r.Log.Info("Kube object protection disabled; don't watch kube objects requests")
 	}
@@ -154,6 +164,30 @@ func (r *VolumeReplicationGroupReconciler) configMapFun(
 ) []reconcile.Request {
 	log := ctrl.Log.WithName("configmap").WithName("VolumeReplicationGroup")
 
+	// Handle default-excluded-resources ConfigMap
+	if configmap.GetName() == velero.DefaultExcludedResourcesConfigMapName &&
+		configmap.GetNamespace() == RamenOperatorNamespace() {
+		log.Info("Update in default-excluded-resources ConfigMap, reloading")
+
+		// Reload the excluded resources
+		if r.excludedResourcesMgr != nil {
+			if excludedResources, err := r.excludedResourcesMgr.ReloadExcludedResources(ctx); err != nil {
+				log.Error(err, "Failed to reload excluded resources")
+			} else {
+				// Update the cached excluded resources in the reconciler
+				r.excludedResourcesMutex.Lock()
+				r.cachedExcludedResources = excludedResources
+				r.excludedResourcesMutex.Unlock()
+				log.Info("Updated cached excluded resources", "count", len(excludedResources))
+			}
+		}
+
+		// No need to reconcile all VRGs for this change
+		// The new exclusions will be used in the next backup
+		return []reconcile.Request{}
+	}
+
+	// Handle ramen operator config ConfigMap
 	if configmap.GetName() != DrClusterOperatorConfigMapName || configmap.GetNamespace() != RamenOperatorNamespace() {
 		return []reconcile.Request{}
 	}
@@ -400,7 +434,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=recipes,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch;get;create;patch;update
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups="kubevirt.io",resources=virtualmachines,verbs=get;list;watch;patch;update;delete
@@ -467,6 +501,8 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 				"Please install velero/oadp and restart the operator", v.instance.Namespace, v.instance.Name)
 	}
 
+	r.ensureExcludedResourcesCM(ctx, ramenConfig, log)
+
 	v.volSyncHandler = volsync.NewVSHandler(ctx, r.Client, log, v.instance,
 		v.instance.Spec.Async, cephFSCSIDriverNameOrDefault(v.ramenConfig),
 		volSyncDestinationCopyMethodOrDefault(v.ramenConfig), adminNamespaceVRG)
@@ -486,6 +522,28 @@ func (r *VolumeReplicationGroupReconciler) Reconcile(ctx context.Context, req ct
 		"VolRep count", len(v.volRepPVCs), "VolSync count", len(v.volSyncPVCs))
 
 	return res, nil
+}
+
+func (r *VolumeReplicationGroupReconciler) ensureExcludedResourcesCM(ctx context.Context,
+	ramenConfig *ramendrv1alpha1.RamenConfig, log logr.Logger,
+) {
+	// Ensure default-excluded-resources ConfigMap exists on first reconciliation
+	if !ramenConfig.KubeObjectProtection.Disabled && r.excludedResourcesMgr != nil {
+		r.excludedResourcesMutex.RLock()
+		needsInit := len(r.cachedExcludedResources) == 0
+		r.excludedResourcesMutex.RUnlock()
+
+		if needsInit {
+			if excludedResources, err := r.excludedResourcesMgr.EnsureConfigMap(ctx); err != nil {
+				log.Error(err, "Failed to ensure excluded resources ConfigMap")
+			} else {
+				r.excludedResourcesMutex.Lock()
+				r.cachedExcludedResources = excludedResources
+				r.excludedResourcesMutex.Unlock()
+				log.Info("Initialized excluded resources from ConfigMap", "count", len(excludedResources))
+			}
+		}
+	}
 }
 
 type cachedObjectStorer struct {

--- a/internal/controller/vrg_kubeobjects.go
+++ b/internal/controller/vrg_kubeobjects.go
@@ -377,11 +377,14 @@ func (v *VRGInstance) kubeObjectsGroupCapture(
 
 		request, ok := requests[requestName]
 		if !ok {
+			// Merge ConfigMap default exclusions with recipe-level exclusions
+			captureSpec := v.mergeExcludedResources(captureGroup.Spec)
+
 			if _, err := v.reconciler.kubeObjects.ProtectRequestCreate(
 				v.ctx, v.reconciler.Client, v.log,
 				s3StoreAccessor.S3CompatibleEndpoint, s3StoreAccessor.S3Bucket, s3StoreAccessor.S3Region,
 				pathName, s3StoreAccessor.VeleroNamespaceSecretKeyRef, s3StoreAccessor.CACertificates,
-				captureGroup.Spec, veleroNamespaceName, requestName,
+				captureSpec, veleroNamespaceName, requestName,
 				labels, annotations,
 			); err != nil {
 				log1.Error(err, "Kube objects group capture request submit error")
@@ -940,6 +943,43 @@ func (v *VRGInstance) kubeObjectsProtectionDelete(result *ctrl.Result) error {
 		v.veleroNamespaceName(),
 		util.OwnerLabels(vrg),
 	)
+}
+
+// mergeExcludedResources merges ConfigMap default exclusions with recipe-level exclusions.
+// Returns a new Spec with the merged exclusions.
+func (v *VRGInstance) mergeExcludedResources(spec kubeobjects.Spec) kubeobjects.Spec {
+	// Get default exclusions from ConfigMap
+	v.reconciler.excludedResourcesMutex.RLock()
+	defaultExclusions := v.reconciler.cachedExcludedResources
+	v.reconciler.excludedResourcesMutex.RUnlock()
+
+	if len(defaultExclusions) == 0 {
+		// No default exclusions, return original spec
+		return spec
+	}
+
+	// Create a new spec with merged exclusions
+	// ConfigMap defaults + Recipe group exclusions
+	mergedExclusions := make([]string, 0, len(defaultExclusions)+len(spec.ExcludedResources))
+	mergedExclusions = append(mergedExclusions, defaultExclusions...)
+	mergedExclusions = append(mergedExclusions, spec.ExcludedResources...)
+
+	// Remove duplicates
+	seen := make(map[string]bool, len(mergedExclusions))
+	uniqueExclusions := make([]string, 0, len(mergedExclusions))
+
+	for _, resource := range mergedExclusions {
+		if !seen[resource] {
+			seen[resource] = true
+			uniqueExclusions = append(uniqueExclusions, resource)
+		}
+	}
+
+	// Create a copy of the spec with merged exclusions
+	mergedSpec := spec
+	mergedSpec.ExcludedResources = uniqueExclusions
+
+	return mergedSpec
 }
 
 func kubeObjectsRequestsWatch(


### PR DESCRIPTION
This commit implements a flexible, user-configurable approach for managing Velero backup excluded resources through a ConfigMap.

1. On startup, VRG controller ensures default-excluded-resources ConfigMap exists
2. If missing, creates it with hardcoded defaults:
   - volumereplications.replication.storage.openshift.io
   - volumegroupreplications.replication.storage.openshift.io
   - replicationsources.volsync.backube
   - replicationdestinations.volsync.backube
   - persistentvolumeclaims
   - persistentvolumes
   - endpointslices.discovery.k8s.io
   - endpoints
   - volumesnapshots.snapshot.storage.k8s.io
   - volumegroupsnapshots.groupsnapshot.storage.k8s.io

3. Excluded resources are aggregated as: ConfigMap defaults ∪ Recipe exclusions
4. ConfigMap changes are detected and reloaded automatically
5. Validation warns if critical resources are removed.


Assited-by: Claude AI

(cherry picked from commit b2add475afb51e936a1db8c1feb95039303c55f9)