### PR TITLE
DFBUGS-2771: create recipe on destination cluster automatically

### DIFF
--- a/internal/controller/controllers_utils_test.go
+++ b/internal/controller/controllers_utils_test.go
@@ -341,11 +341,6 @@ func drclusterConditionExpect(
 }
 
 func validateClusterManifest(apiReader client.Reader, drcluster *ramen.DRCluster, disabled bool) {
-	expectedCount := 9
-	if disabled {
-		expectedCount = 4
-	}
-
 	clusterName := drcluster.Name
 
 	key := types.NamespacedName{
@@ -356,12 +351,35 @@ func validateClusterManifest(apiReader client.Reader, drcluster *ramen.DRCluster
 	manifestWork := &workv1.ManifestWork{}
 
 	Eventually(
-		func(g Gomega) []workv1.Manifest {
+		func(g Gomega) {
 			g.Expect(apiReader.Get(context.TODO(), key, manifestWork)).To(Succeed())
 
-			return manifestWork.Spec.Workload.Manifests
+			// Validate base ClusterRoles are always present (5 manifests)
+			g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+				HaveField("RawExtension.Raw", ContainSubstring("volrepgroup-edit"))))
+			g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+				HaveField("RawExtension.Raw", ContainSubstring("mmode-edit"))))
+			g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+				HaveField("RawExtension.Raw", ContainSubstring("drclusterconfig-edit"))))
+			g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+				HaveField("RawExtension.Raw", ContainSubstring("networkfence-edit"))))
+			g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+				HaveField("RawExtension.Raw", ContainSubstring("recipe-edit"))))
+
+			if !disabled {
+				// When deployment automation is enabled, validate additional manifests (5 more)
+				g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+					HaveField("RawExtension.Raw", ContainSubstring("olm-edit"))))
+				g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+					HaveField("RawExtension.Raw", ContainSubstring("OperatorGroup"))))
+				g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+					HaveField("RawExtension.Raw", ContainSubstring("Subscription"))))
+				// Two Namespace manifests
+				g.Expect(manifestWork.Spec.Workload.Manifests).To(ContainElement(
+					HaveField("RawExtension.Raw", And(ContainSubstring("Namespace"), ContainSubstring("ramen")))))
+			}
 		}, timeout, interval,
-	).Should(HaveLen(expectedCount))
+	).Should(Succeed())
 
 	Expect(manifestWork.GetAnnotations()[controllers.DRClusterNameAnnotation]).Should(Equal(clusterName))
 	// TODO: Validate fencing status

--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -14,11 +14,13 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	recipev1 "github.com/ramendr/recipe/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	clrapiv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
+	ocmworkv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	rmn "github.com/ramendr/ramen/api/v1alpha1"
@@ -3157,4 +3159,100 @@ func (d *DRPCInstance) filterSCCAnnotations(annotations map[string]string) (map[
 	}
 
 	return filteredAnnotations, nil
+}
+
+func (d *DRPCInstance) ensureRecipeManifestWork(srcCluster, dstCluster string) error {
+	if d.instance.Spec.KubeObjectProtection == nil || d.instance.Spec.KubeObjectProtection.RecipeRef == nil {
+		return nil
+	}
+
+	recipeName := d.instance.Spec.KubeObjectProtection.RecipeRef.Name
+	recipeNamespace := d.instance.Spec.KubeObjectProtection.RecipeRef.Namespace
+
+	// Always fetch the latest recipe from source cluster
+	recipe, err := d.reconciler.MCVGetter.GetRecipeFromManagedCluster(srcCluster, recipeName, recipeNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to get recipe %s/%s in cluster %s: %w", recipeNamespace, recipeName, srcCluster, err)
+	}
+
+	// Check if recipe MW exists on destination
+	existingMW, err := d.mwu.FindManifestWorkByType(rmnutil.MWTypeRecipe, dstCluster)
+	if err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get recipe MW in cluster %s: %w", dstCluster, err)
+		}
+		// MW doesn't exist, create it
+		return d.mwu.CreateOrUpdateRecipeManifestWork(recipe, dstCluster)
+	}
+
+	// MW exists, check if recipe needs update by comparing Generation or ResourceVersion
+	// Extract existing recipe from ManifestWork and compare
+	if needsUpdate, err := d.recipeNeedsUpdate(existingMW, recipe); err != nil {
+		return fmt.Errorf("failed to check if recipe needs update: %w", err)
+	} else if needsUpdate {
+		d.log.Info("Recipe has been updated, updating ManifestWork",
+			"recipe", recipeName,
+			"namespace", recipeNamespace,
+			"srcCluster", srcCluster,
+			"dstCluster", dstCluster,
+			"generation", recipe.Generation,
+			"resourceVersion", recipe.ResourceVersion)
+
+		return d.mwu.CreateOrUpdateRecipeManifestWork(recipe, dstCluster)
+	}
+
+	return nil
+}
+
+// recipeNeedsUpdate compares the recipe in the ManifestWork with the source recipe
+// Returns true if the recipe needs to be updated
+func (d *DRPCInstance) recipeNeedsUpdate(mw *ocmworkv1.ManifestWork, sourceRecipe *recipev1.Recipe) (bool, error) {
+	if mw == nil || len(mw.Spec.Workload.Manifests) == 0 {
+		return true, nil
+	}
+
+	// Extract recipe from ManifestWork
+	existingRecipe := &recipev1.Recipe{}
+	if err := rmnutil.ExtractResourceFromManifestWork(mw, existingRecipe,
+		schema.GroupVersionKind{
+			Group:   recipev1.GroupVersion.Group,
+			Version: recipev1.GroupVersion.Version,
+			Kind:    "Recipe",
+		}); err != nil {
+		return false, fmt.Errorf("failed to extract recipe from ManifestWork: %w", err)
+	}
+
+	// Compare Spec - this is the most important part
+	if !reflect.DeepEqual(existingRecipe.Spec, sourceRecipe.Spec) {
+		d.log.V(1).Info("Recipe Spec has changed", "recipe", sourceRecipe.Name)
+
+		return true, nil
+	}
+
+	// Compare Labels - only if both have labels
+	// Handle nil vs empty map equivalence
+	if !mapsEqual(existingRecipe.Labels, sourceRecipe.Labels) {
+		d.log.V(1).Info("Recipe Labels have changed", "recipe", sourceRecipe.Name)
+
+		return true, nil
+	}
+
+	// Compare Annotations - only if both have annotations
+	// Handle nil vs empty map equivalence
+	if !mapsEqual(existingRecipe.Annotations, sourceRecipe.Annotations) {
+		d.log.V(1).Info("Recipe Annotations have changed", "recipe", sourceRecipe.Name)
+
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// mapsEqual compares two string maps, treating nil and empty maps as equivalent
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+
+	return reflect.DeepEqual(a, b)
 }

--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1060,7 +1060,7 @@ func verifyVRGManifestWorkCreatedAsPrimary(namespace, managedCluster string) {
 		return err == nil
 	}, timeout, interval).Should(BeTrue())
 
-	Expect(len(createdVRGRolesManifest.Spec.Workload.Manifests)).To(Equal(9))
+	Expect(len(createdVRGRolesManifest.Spec.Workload.Manifests)).To(Equal(10))
 
 	vrgClusterRoleManifest := createdVRGRolesManifest.Spec.Workload.Manifests[0]
 	Expect(vrgClusterRoleManifest).ToNot(BeNil())

--- a/internal/controller/drplacementcontrolvolsync.go
+++ b/internal/controller/drplacementcontrolvolsync.go
@@ -291,6 +291,13 @@ func (d *DRPCInstance) createOrUpdateSecondaryManifestWork(srcCluster string) (c
 					d.instance.Namespace, dstCluster)
 		}
 
+		err = d.ensureRecipeManifestWork(srcCluster, dstCluster)
+		if err != nil {
+			return ctrlutil.OperationResultNone,
+				fmt.Errorf("creating ManifestWork couldn't ensure recipe on cluster %s exists",
+					dstCluster)
+		}
+
 		annotations := make(map[string]string)
 
 		annotations[DRPCNameAnnotation] = d.instance.Name

--- a/internal/controller/fake_mcv_test.go
+++ b/internal/controller/fake_mcv_test.go
@@ -12,6 +12,7 @@ import (
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	recipev1 "github.com/ramendr/recipe/api/v1alpha1"
 	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -200,5 +201,11 @@ func (f FakeMCVGetter) DeleteManagedClusterView(clusterName, mcvName string, log
 }
 
 func (f FakeMCVGetter) GetNSFromManagedCluster(managedCluster, resourceName string) (*corev1.Namespace, error) {
+	return nil, nil
+}
+
+func (f FakeMCVGetter) GetRecipeFromManagedCluster(managedCluster, resourceName,
+	resourceNamespace string,
+) (*recipev1.Recipe, error) {
 	return nil, nil
 }

--- a/internal/controller/util/mcv_util.go
+++ b/internal/controller/util/mcv_util.go
@@ -14,6 +14,7 @@ import (
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	"github.com/go-logr/logr"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	recipev1 "github.com/ramendr/recipe/api/v1alpha1"
 	groupsnapv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -90,6 +91,9 @@ type ManagedClusterViewGetter interface {
 
 	GetNSFromManagedCluster(
 		managedCluster, resourceName string) (*corev1.Namespace, error)
+
+	GetRecipeFromManagedCluster(
+		managedCluster, resourceName, resourceNamespace string) (*recipev1.Recipe, error)
 
 	ListVGRClassMCVs(managedCluster string) (*viewv1beta1.ManagedClusterViewList, error)
 
@@ -416,6 +420,26 @@ func (m ManagedClusterViewGetterImpl) GetNSFromManagedCluster(cluster, resourceN
 		ns)
 
 	return ns, err
+}
+
+func (m ManagedClusterViewGetterImpl) GetRecipeFromManagedCluster(cluster, resourceName,
+	resourceNamespace string,
+) (*recipev1.Recipe, error) {
+	recipe := &recipev1.Recipe{}
+
+	err := m.getResourceFromManagedCluster(
+		resourceName,
+		resourceNamespace,
+		cluster,
+		map[string]string{},
+		map[string]string{},
+		BuildManagedClusterViewName(resourceName, resourceNamespace, "recipe"),
+		"Recipe",
+		recipev1.GroupVersion.Group,
+		recipev1.GroupVersion.Version,
+		recipe)
+
+	return recipe, err
 }
 
 func (m ManagedClusterViewGetterImpl) ListVRClassMCVs(cluster string) (*viewv1beta1.ManagedClusterViewList, error) {

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -11,6 +11,7 @@ import (
 
 	csiaddonsv1alpha1 "github.com/csi-addons/kubernetes-csi-addons/api/csiaddons/v1alpha1"
 	"github.com/go-logr/logr"
+	recipev1 "github.com/ramendr/recipe/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -53,6 +54,7 @@ const (
 	MWTypeVRClass   string = "vrc"
 	MWTypeVGRClass  string = "vgrc"
 	MWTypeDRCConfig string = "drcconfig"
+	MWTypeRecipe    string = "recipe"
 )
 
 type MWUtil struct {
@@ -393,6 +395,44 @@ func Namespace(name string) *corev1.Namespace {
 	}
 }
 
+// Recipe MW creation
+func (mwu *MWUtil) CreateOrUpdateRecipeManifestWork(
+	recipe *recipev1.Recipe, managedClusterNamespace string,
+) error {
+	manifest, err := mwu.GenerateManifest(prepareRecipeForMW(recipe))
+	if err != nil {
+		return err
+	}
+
+	manifests := []ocmworkv1.Manifest{*manifest}
+	mwName := fmt.Sprintf(ManifestWorkNameFormat, mwu.InstName, mwu.TargetNamespace, MWTypeRecipe)
+	manifestWork := mwu.newManifestWork(
+		mwName,
+		managedClusterNamespace,
+		map[string]string{
+			"recipe": recipe.Name,
+		},
+		manifests,
+		map[string]string{},
+	)
+	manifestWork.Spec.DeleteOption = &ocmworkv1.DeleteOption{
+		PropagationPolicy: ocmworkv1.DeletePropagationPolicyTypeOrphan,
+	}
+	_, err = mwu.createOrUpdateManifestWork(manifestWork, managedClusterNamespace)
+
+	return err
+}
+
+func prepareRecipeForMW(recipe *recipev1.Recipe) *recipev1.Recipe {
+	recipeCopy := &recipev1.Recipe{
+		TypeMeta:   metav1.TypeMeta{Kind: "Recipe", APIVersion: recipev1.GroupVersion.String()},
+		ObjectMeta: ObjectMetaEmbedded(&recipe.ObjectMeta),
+	}
+	recipeCopy.Spec = recipe.Spec
+
+	return recipeCopy
+}
+
 func ExtractResourceFromManifestWork(
 	mw *ocmworkv1.ManifestWork,
 	object client.Object,
@@ -459,6 +499,7 @@ func (mwu *MWUtil) CreateOrUpdateDrClusterManifestWork(
 			mModeClusterRole,
 			drClusterConfigRole,
 			networkFenceClusterRole,
+			recipeClusterRole,
 		},
 		objectsToAppend...,
 	)
@@ -554,6 +595,23 @@ var (
 				APIGroups: []string{csiaddonsv1alpha1.GroupVersion.Group},
 				Resources: []string{"networkfences"},
 				Verbs:     []string{"create", "get", "list", "update", "delete", "watch"},
+			},
+		},
+	}
+
+	recipeClusterRole = &rbacv1.ClusterRole{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterRole", APIVersion: "rbac.authorization.k8s.io/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "open-cluster-management:klusterlet-work-sa:agent:recipe-edit",
+			Labels: map[string]string{
+				ClusterRoleAggregateLabel: "true",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{recipev1.GroupVersion.Group},
+				Resources: []string{"recipes"},
+				Verbs:     []string{"create", "get", "list", "update"},
 			},
 		},
 	}


### PR DESCRIPTION
Add support for propagating Recipe resources from source cluster to destination cluster during DR operations.

When a DRPC specifies a RecipeRef in KubeObjectProtection, the Recipe is now automatically fetched from the source cluster using ManagedClusterView and deployed to the destination cluster via ManifestWork before VRG creation.

- Add `GetRecipeFromManagedCluster()` to MCV utility to fetch Recipe from managed clusters
- Add `CreateOrUpdateRecipeManifestWork()` to MW utility to create Recipe ManifestWork on destination clusters
- Add `ensureRecipeManifestWork()` to DRPC controller to orchestrate Recipe propagation during secondary replication setup
- Integrate Recipe propagation into VolSync secondary setup flow
- Add `MWTypeRecipe` constant for Recipe ManifestWork type
- Update test mocks to support Recipe MCV operations

The Recipe ManifestWork uses orphan deletion policy to preserve the Recipe resource when the ManifestWork is deleted, allowing Recipe reuse across DR operations.


(cherry picked from commit cdfc8345a40cfab0e9f5f60f4fbaa88af1227a8b)