### PR TITLE
DFBUGS-6239: config: Enable scc retention across peers by default

### DIFF
--- a/config/samples/ramendr_v1alpha1_ramenconfig.yaml
+++ b/config/samples/ramendr_v1alpha1_ramenconfig.yaml
@@ -32,4 +32,4 @@ drClusterOperator:
   catalogSourceNamespaceName: ramen-system
   clusterServiceVersionName: ramen-dr-cluster-operator.v0.0.1
 veleroNamespaceName: "openshift-adp"
-retainNamespaceSCCAcrossPeers: false
+retainNamespaceSCCAcrossPeers: true

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -90,8 +90,9 @@ func DefaultRamenConfig(controllerType ramendrv1alpha1.ControllerType) *ramendrv
 			LeaderElect:  &leaderElect,
 			ResourceName: leaderElectionResourceName,
 		},
-		RamenOpsNamespace:         "ramen-ops",
-		VolumeUnprotectionEnabled: true,
+		RamenOpsNamespace:             "ramen-ops",
+		VolumeUnprotectionEnabled:     true,
+		RetainNamespaceSCCAcrossPeers: true,
 	}
 
 	cfg.DrClusterOperator.DeploymentAutomationEnabled = true


### PR DESCRIPTION
Default retainNamespaceSCCAcrossPeers to true

Retain Security Context Constraints annotations when creating namespaces on secondary clusters during DR enablement.