### PR TITLE
DFBUGS-6756: Fix VGR selector logic for offloaded storage and improve logging

### DIFF
--- a/internal/controller/util/secrets_util.go
+++ b/internal/controller/util/secrets_util.go
@@ -478,7 +478,7 @@ func (sutil *SecretsUtil) deletePolicyResources(
 ) error {
 	policyName, plBindingName, plRuleName, _ := GeneratePolicyResourceNames(secret.Name, format)
 
-	sutil.Log.Info("Deleting secret policy", "secret", secret.Name)
+	sutil.Log.Info("Deleting secret policy", "secret", secret.Name, "namespace", namespace)
 
 	plRuleBindingObject := &gppv1.PlacementBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -510,6 +510,7 @@ func (sutil *SecretsUtil) deletePolicyResources(
 			Namespace: namespace,
 		},
 	}
+
 	if err := sutil.Client.Delete(sutil.Ctx, plRuleObject); err != nil && !k8serrors.IsNotFound(err) {
 		sutil.Log.Error(err, "unable to delete placement rule", "secret", secret.Name)
 

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -841,9 +841,10 @@ func (v *VRGInstance) createVGR(vrNamespacedName types.NamespacedName,
 	isGlobal := v.hasGlobalVGRLabel()
 
 	var selector *metav1.LabelSelector
-	if isGlobal {
+	if isGlobal || offloaded {
 		// Global VGRs are shared across VRGs, so select by consistency group only
 		// to include PVCs from all VRGs.
+		// Offloaded follow the same logic as global since they are also shared and not owned by VRG.
 		selector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				rmnutil.ConsistencyGroupLabel: cg,


### PR DESCRIPTION
Include offloaded volumes in the VGR label selector. PVC filtering is based on CG label only.


(cherry picked from commit 86e010a2a43ff555011e2b292e76aa412816d5f1)