### PR TITLE
DFBUGS-6518: Fix exec hook command parsing for complex shell quoting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/backube/volsync v0.11.0
 	github.com/csi-addons/kubernetes-csi-addons v0.10.1-0.20250723164929-7735388cf184
 	github.com/go-logr/logr v1.4.3
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.2.0
 	github.com/onsi/ginkgo/v2 v2.23.4

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/controller/hooks/exec_command_parse_test.go
+++ b/internal/controller/hooks/exec_command_parse_test.go
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hooks_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ramendr/ramen/internal/controller/hooks"
+)
+
+func TestParseCommandArray(t *testing.T) {
+	raw := `["sudo","find","/tmp","-maxdepth","1"]`
+	out, err := hooks.ConvertCommandToStringArray(raw)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sudo", "find", "/tmp", "-maxdepth", "1"}, out)
+}
+
+func TestParseCommandQuotedScript(t *testing.T) {
+	// argv must preserve single-quoted -c script and end with ';' for find -exec (not '\\;' split across tokens).
+	cmd := `sudo find /mnt/blumeta0 -type l -exec sh -c 'ln -snf "$(readlink -f "{}")" "{}"' \;`
+	out, err := hooks.ConvertCommandToStringArray(cmd)
+	require.NoError(t, err)
+	require.Equal(t, ";", out[len(out)-1])
+
+	idx := -1
+
+	for i := range out {
+		if out[i] == "-c" {
+			idx = i
+
+			break
+		}
+	}
+
+	require.NotEqual(t, -1, idx)
+	require.Less(t, idx+1, len(out))
+	assert.Contains(t, out[idx+1], "readlink")
+}
+
+func TestParseCommandError(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "unclosed single quote",
+			command: `echo 'broken`,
+		},
+		{
+			name:    "unclosed double quote",
+			command: `echo "broken`,
+		},
+		{
+			name:    "unclosed backslash",
+			command: `echo \`,
+		},
+		{
+			name:    "invalid JSON array",
+			command: `[not json]`,
+		},
+		{
+			name:    "JSON array trailing comma",
+			command: `["sudo", "find",]`,
+		},
+		{
+			name:    "JSON array missing comma",
+			command: `[true false]`,
+		},
+		{
+			name:    "JSON array numeric trailing comma",
+			command: `[1,2,3,]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := hooks.ConvertCommandToStringArray(tt.command)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseCommandComplexNestedQuotes(t *testing.T) {
+	// Test the actual complex command from the user's issue
+	// nolint:lll // Long command string is necessary for testing
+	cmd := `/bin/bash -c 'sudo find /mnt/blumeta0 -type l -exec /bin/bash -c '\''for p; do t=$(readlink "$p"); case "$t" in opt/*|usr/*|var/*|etc/*|bin/*|sbin/*|lib/*|lib64/*|mnt/*) o=$(stat -c "%u:%g" "$p"); echo -e "[FIX] $p\n  current -> $t\n  new     -> /$t\n  owner   -> $o"; sudo ln -snf "/$t" "$p" && sudo chown -h "$o" "$p"; echo ;; esac; done'\'' _ {} +; sudo rm -rfv /mnt/bludata0/sshkeys'`
+	out, err := hooks.ConvertCommandToStringArray(cmd)
+	require.NoError(t, err)
+
+	//nolint:lll // Long expected script string must match parsed output exactly
+	wantScript := `sudo find /mnt/blumeta0 -type l -exec /bin/bash -c 'for p; do t=$(readlink "$p"); case "$t" in opt/*|usr/*|var/*|etc/*|bin/*|sbin/*|lib/*|lib64/*|mnt/*) o=$(stat -c "%u:%g" "$p"); echo -e "[FIX] $p\n  current -> $t\n  new     -> /$t\n  owner   -> $o"; sudo ln -snf "/$t" "$p" && sudo chown -h "$o" "$p"; echo ;; esac; done' _ {} +; sudo rm -rfv /mnt/bludata0/sshkeys`
+	want := []string{"/bin/bash", "-c", wantScript}
+	assert.Equal(t, want, out)
+}
+
+func TestParseCommandDoubleQuote(t *testing.T) {
+	cmd := `sh -c "echo $HOME and \"quoted\" text"`
+	out, err := hooks.ConvertCommandToStringArray(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sh", "-c", `echo $HOME and "quoted" text`}, out)
+}
+
+func TestParseCommandSingleQuote(t *testing.T) {
+	cmd := `sh -c 'echo $HOME stays literal'`
+	out, err := hooks.ConvertCommandToStringArray(cmd)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sh", "-c", "echo $HOME stays literal"}, out)
+}
+
+func TestParseCommandEscapedCharacters(t *testing.T) {
+	cmd := `echo hello\ world "test\"quote"`
+	out, err := hooks.ConvertCommandToStringArray(cmd)
+	require.NoError(t, err)
+	// shlex should handle escaped spaces and quotes
+	require.Greater(t, len(out), 0)
+	assert.Equal(t, "echo", out[0])
+	assert.Equal(t, "hello world", out[1])
+	assert.Equal(t, `test"quote`, out[2])
+}
+
+func TestParseCommandFindExecSemicolon(t *testing.T) {
+	// Verify that find -exec with \; is properly parsed
+	cmd := `find /tmp -name "*.txt" -exec rm {} \;`
+	out, err := hooks.ConvertCommandToStringArray(cmd)
+	require.NoError(t, err)
+
+	// The semicolon should be preserved as a separate token
+	assert.Contains(t, out, ";", "Semicolon should be in the parsed output")
+	assert.Equal(t, ";", out[len(out)-1], "Last token should be semicolon")
+}
+
+func TestParseCommandMultipleSpaces(t *testing.T) {
+	cmd := `echo    hello     world`
+	out, err := hooks.ConvertCommandToStringArray(cmd)
+	require.NoError(t, err)
+	// Multiple spaces should be collapsed
+	assert.Equal(t, []string{"echo", "hello", "world"}, out)
+}

--- a/internal/controller/hooks/exec_hook.go
+++ b/internal/controller/hooks/exec_hook.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/shlex"
 	recipev1 "github.com/ramendr/recipe/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -309,7 +310,7 @@ func getContainerName(containerName string, pod *corev1.Pod) string {
 	return pod.Spec.Containers[0].Name
 }
 
-func covertCommandToStringArray(command string) ([]string, error) {
+func ConvertCommandToStringArray(command string) ([]string, error) {
 	var cmd []string
 	if isJSONArray(command) {
 		err := json.Unmarshal([]byte(command), &cmd)
@@ -317,7 +318,13 @@ func covertCommandToStringArray(command string) ([]string, error) {
 			return []string{}, err
 		}
 	} else {
-		cmd = strings.Split(command, " ")
+		// Use shlex to properly parse shell commands with quotes and escapes
+		var err error
+
+		cmd, err = shlex.Split(command)
+		if err != nil {
+			return []string{}, fmt.Errorf("failed to parse command: %w", err)
+		}
 	}
 
 	return cmd, nil

--- a/internal/controller/hooks/exec_pod_lister_daemonset.go
+++ b/internal/controller/hooks/exec_pod_lister_daemonset.go
@@ -92,7 +92,7 @@ func (l *DaemonSetPodLister) getPodsFromDaemonSets(daemonSets []appsv1.DaemonSet
 				continue
 			}
 
-			cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+			cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 			if err != nil {
 				return execPods, fmt.Errorf("error converting command to string array: %w", err)
 			}
@@ -127,7 +127,7 @@ func (l *DaemonSetPodLister) getAllPodsFromDaemonSets(
 ) ([]ExecPodSpec, error) {
 	execPods := make([]ExecPodSpec, 0)
 
-	cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+	cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 	if err != nil {
 		return execPods, fmt.Errorf("error converting command to string array: %w", err)
 	}

--- a/internal/controller/hooks/exec_pod_lister_deployment.go
+++ b/internal/controller/hooks/exec_pod_lister_deployment.go
@@ -127,7 +127,7 @@ func (l *DeploymentPodLister) getPodFromReplicaSet(rsName, rsNS string) (*ExecPo
 	for i := range podList.Items {
 		pod := &podList.Items[i]
 		if IsPodOwnedByRS(pod, rsName) {
-			cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+			cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 			if err != nil {
 				return nil, fmt.Errorf("error converting command to string array: %w", err)
 			}
@@ -178,7 +178,7 @@ func (l *DeploymentPodLister) getReplicaSetsOwnedByDeployments(deps []appsv1.Dep
 }
 
 func (l *DeploymentPodLister) getExecPodsFromReplicaSets(replicasets []appsv1.ReplicaSet) ([]ExecPodSpec, error) {
-	cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+	cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 	if err != nil {
 		return []ExecPodSpec{}, fmt.Errorf("error converting command to string array: %w", err)
 	}

--- a/internal/controller/hooks/exec_pod_lister_direct.go
+++ b/internal/controller/hooks/exec_pod_lister_direct.go
@@ -146,7 +146,7 @@ func (l *DirectPodLister) filterExecPodsUsingRegex(podList *corev1.PodList, re *
 ) ([]ExecPodSpec, error) {
 	execPods := make([]ExecPodSpec, 0)
 
-	cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+	cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 	if err != nil {
 		log.Error(err, "error occurred during exec hook execution", "command being converted:", l.Hook.Op.Command)
 
@@ -166,7 +166,7 @@ func (l *DirectPodLister) filterExecPodsUsingRegex(podList *corev1.PodList, re *
 func (l *DirectPodLister) getExecPodSpecsFromPodList(podList *corev1.PodList, log logr.Logger) ([]ExecPodSpec, error) {
 	execPods := make([]ExecPodSpec, 0)
 
-	cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+	cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 	if err != nil {
 		log.Error(err, "error occurred during exec hook execution", "command being converted:", l.Hook.Op.Command)
 

--- a/internal/controller/hooks/exec_pod_lister_statefulset.go
+++ b/internal/controller/hooks/exec_pod_lister_statefulset.go
@@ -90,7 +90,7 @@ func (l *StatefulSetPodLister) getPodsFromStatefulSets(statefulSets []appsv1.Sta
 				return execPods, fmt.Errorf("error occurred while getting pod for statefulset: %w", err)
 			}
 
-			cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+			cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 			if err != nil {
 				return execPods, fmt.Errorf("error converting command to string array: %w", err)
 			}
@@ -107,7 +107,7 @@ func (l *StatefulSetPodLister) getAllPodsFromStatefulSets(
 ) ([]ExecPodSpec, error) {
 	execPods := make([]ExecPodSpec, 0)
 
-	cmd, err := covertCommandToStringArray(l.Hook.Op.Command)
+	cmd, err := ConvertCommandToStringArray(l.Hook.Op.Command)
 	if err != nil {
 		return execPods, fmt.Errorf("error converting command to string array: %w", err)
 	}


### PR DESCRIPTION
Replace string splitting with shell lexer (google/shlex) to handle nested quotes, escaping, and complex shell syntax.

Fixes command parsing errors like "missing argument to -exec" when using complex bash commands with nested quotes in exec hooks.

Fixes: redhat.atlassian.net/browse/DFBUGS-6518

