### PR TITLE
DFBUGS-7019: Ensure dryRun works with action as Failover and does gracefully error handling in other cases

### DIFF
--- a/internal/controller/drplacementcontrol.go
+++ b/internal/controller/drplacementcontrol.go
@@ -103,7 +103,7 @@ func (d *DRPCInstance) startProcessing() bool {
 	}
 
 	if processingErr != nil {
-		d.log.Info("Process placement", "error", processingErr.Error())
+		d.log.Error(processingErr, "Failed to process placement")
 
 		return requeue
 	}
@@ -580,6 +580,28 @@ func (d *DRPCInstance) monitorTestFailoverCleanup() (bool, error) {
 }
 
 func (d *DRPCInstance) executeAction() (bool, error) {
+	// Validate dryRun configuration
+	if d.instance.Spec.DryRun {
+		if d.instance.Spec.Action != rmn.ActionFailover {
+			err := fmt.Errorf("dryRun is enabled but action is not failover")
+			d.reconciler.recordFailure(d.ctx, d.instance, d.userPlacement, "ValidationFailed", err.Error(), d.log)
+
+			return false, err
+		}
+
+		// During dryRun, last-app-deployment-cluster always points to where the app is currently running
+		// (it's not updated during test failover). We cannot test failover to the same cluster.
+		lastAppCluster := d.instance.GetAnnotations()[LastAppDeploymentCluster]
+		if d.instance.Spec.FailoverCluster == lastAppCluster {
+			err := fmt.Errorf(
+				"dryRun is enabled, but cannot test failover to cluster %s where the application is currently running",
+				lastAppCluster)
+			d.reconciler.recordFailure(d.ctx, d.instance, d.userPlacement, "ValidationFailed", err.Error(), d.log)
+
+			return false, err
+		}
+	}
+
 	switch d.instance.Spec.Action {
 	case rmn.ActionFailover:
 		return d.RunFailover()

--- a/internal/controller/drplacementcontrol_dryrun_test.go
+++ b/internal/controller/drplacementcontrol_dryrun_test.go
@@ -235,18 +235,102 @@ var _ = Describe("DRPCDryRunTestFailover", func() {
 		})
 
 		Context("When DryRun=true with Relocate action", func() {
-			It("should accept the configuration (though dry-run only applies to Failover)", func() {
+			It("should reject the configuration and not progress", func() {
 				drpc.Spec.Action = rmn.ActionRelocate
 				drpc.Spec.PreferredCluster = West1ManagedCluster
 				drpc.Spec.DryRun = true
 				Expect(k8sClient.Create(context.TODO(), drpc)).To(Succeed())
 
+				// Verify DRPC was created
 				Eventually(func() error {
 					return apiReader.Get(context.TODO(), drpcNamespacedName, drpc)
 				}, timeout, interval).Should(Succeed())
 
+				// The controller should reject this and not progress
+				// We verify by checking that Phase remains empty (not progressing)
+				Consistently(func() rmn.DRState {
+					if err := apiReader.Get(context.TODO(), drpcNamespacedName, drpc); err != nil {
+						return ""
+					}
+
+					return drpc.Status.Phase
+				}, "2s", interval).Should(BeEmpty())
+			})
+		})
+
+		Context("When DryRun=true with Failover", func() {
+			It("should reject when failoverCluster equals last-app-deployment-cluster (initial deployment)", func() {
+				// App initially deployed to East1, trying to test failover to same cluster
+				drpc.Annotations = map[string]string{
+					"drplacementcontrol.ramendr.openshift.io/last-app-cluster": East1ManagedCluster,
+				}
+				drpc.Spec.Action = rmn.ActionFailover
+				drpc.Spec.PreferredCluster = West1ManagedCluster
+				drpc.Spec.FailoverCluster = East1ManagedCluster // Same as last-app-cluster
+				drpc.Spec.DryRun = true
+				Expect(k8sClient.Create(context.TODO(), drpc)).To(Succeed())
+
+				// Verify DRPC was created
+				Eventually(func() error {
+					return apiReader.Get(context.TODO(), drpcNamespacedName, drpc)
+				}, timeout, interval).Should(Succeed())
+
+				// The controller should reject this and not progress
+				Consistently(func() rmn.DRState {
+					if err := apiReader.Get(context.TODO(), drpcNamespacedName, drpc); err != nil {
+						return ""
+					}
+
+					return drpc.Status.Phase
+				}, "2s", interval).Should(BeEmpty())
+			})
+
+			It("should reject when failoverCluster equals last-app-deployment-cluster (after real failover)", func() {
+				// App failed over to East1, trying to test failover to same cluster
+				drpc.Annotations = map[string]string{
+					"ramendr.openshift.io/last-action":                         string(rmn.ActionFailover),
+					"drplacementcontrol.ramendr.openshift.io/last-app-cluster": East1ManagedCluster,
+				}
+				drpc.Spec.Action = rmn.ActionFailover
+				drpc.Spec.PreferredCluster = West1ManagedCluster
+				drpc.Spec.FailoverCluster = East1ManagedCluster // Same as last-app-cluster
+				drpc.Spec.DryRun = true
+				Expect(k8sClient.Create(context.TODO(), drpc)).To(Succeed())
+
+				// Verify DRPC was created
+				Eventually(func() error {
+					return apiReader.Get(context.TODO(), drpcNamespacedName, drpc)
+				}, timeout, interval).Should(Succeed())
+
+				// The controller should reject this and not progress
+				Consistently(func() rmn.DRState {
+					if err := apiReader.Get(context.TODO(), drpcNamespacedName, drpc); err != nil {
+						return ""
+					}
+
+					return drpc.Status.Phase
+				}, "2s", interval).Should(BeEmpty())
+			})
+
+			It("should accept when failoverCluster differs from last-app-deployment-cluster", func() {
+				// App on East1, testing failover to West1 (different cluster)
+				drpc.Annotations = map[string]string{
+					"drplacementcontrol.ramendr.openshift.io/last-app-cluster": East1ManagedCluster,
+				}
+				drpc.Spec.Action = rmn.ActionFailover
+				drpc.Spec.PreferredCluster = East1ManagedCluster
+				drpc.Spec.FailoverCluster = West1ManagedCluster // Different from last-app-cluster
+				drpc.Spec.DryRun = true
+				Expect(k8sClient.Create(context.TODO(), drpc)).To(Succeed())
+
+				// Verify DRPC was created
+				Eventually(func() error {
+					return apiReader.Get(context.TODO(), drpcNamespacedName, drpc)
+				}, timeout, interval).Should(Succeed())
+
+				// Should be accepted since failoverCluster is different from where app is running
 				Expect(drpc.Spec.DryRun).To(BeTrue())
-				Expect(drpc.Spec.Action).To(Equal(rmn.ActionRelocate))
+				Expect(drpc.Spec.Action).To(Equal(rmn.ActionFailover))
 			})
 		})
 


### PR DESCRIPTION
(cherry picked from commit d8b5d897a2a53c07e0b7159ce8e779d074ff000d)