### PR TITLE
DFBUGS-6756: Reconcile when external vgr status change

### DIFF
--- a/internal/controller/util/misc.go
+++ b/internal/controller/util/misc.go
@@ -404,11 +404,11 @@ func IsCRDInstalled(ctx context.Context, apiReader client.Reader, crdName string
 }
 
 func CreateVGRName(prefix string, suffix string) string {
-	return TrimToK8sResourceNameLength("vgr-" + prefix + "-" + suffix)
+	return TrimToK8sResourceNameLength("vgr-" + strings.ToLower(prefix) + "-" + strings.ToLower(suffix))
 }
 
 func GlobalVGRName(groupReplicationID string) string {
-	return TrimToK8sResourceNameLength("global-" + groupReplicationID)
+	return TrimToK8sResourceNameLength("global-" + strings.ToLower(groupReplicationID))
 }
 
 func IsPVCMarkedForVolSync(annotations map[string]string) bool {

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -1572,7 +1572,7 @@ func (v *VSHandler) cleanupRS(rs *volsyncv1alpha1.ReplicationSource, pvcName, pv
 ) error {
 	if !skipPVCDisownership {
 		if err := v.RemoveOwnerFromPVC(rs, pvcName, pvcNamespace); err != nil {
-			v.log.Error(err, "Failed to disown PVC before deleting RD", "rs", rs.GetName(), "error", err)
+			v.log.Error(err, "Failed to disown PVC before deleting RS", "rs", rs.GetName(), "error", err)
 
 			return err
 		}

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2421,6 +2421,7 @@ func (r *VolumeReplicationGroupReconciler) filterVRGForOffloadedVGR(
 	ownerNamespace, ownerName, ok := util.OwnerNamespaceNameAndName(vgr.GetLabels())
 	if !ok {
 		log.V(1).Info("VGR does not have owner labels, skipping")
+
 		return req
 	}
 

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -2362,6 +2362,8 @@ func (r *VolumeReplicationGroupReconciler) VGRMapFunc(ctx context.Context, obj c
 	// Filter VRGs by global VGR label, if VGR exists in operator namespace.
 	if vgr.Namespace == RamenOperatorNamespace() {
 		return r.filterGlobalVGRVRGs(vgr.Name, vgrLog)
+	} else if vgr.Spec.External {
+		return r.filterVRGForOffloadedVGR(vgr, vgrLog)
 	}
 
 	return filterVRGDependentObjects(r.Client, obj, vgrLog)
@@ -2406,6 +2408,51 @@ func (r *VolumeReplicationGroupReconciler) filterGlobalVGRVRGs(
 	}
 
 	log.Info("Enqueuing VRGs for shared VGR change", "vrgs", names)
+
+	return req
+}
+
+func (r *VolumeReplicationGroupReconciler) filterVRGForOffloadedVGR(
+	vgr *volrep.VolumeGroupReplication, log logr.Logger,
+) []reconcile.Request {
+	req := []reconcile.Request{}
+
+	// Get VRG owner information from VGR labels
+	ownerNamespace, ownerName, ok := util.OwnerNamespaceNameAndName(vgr.GetLabels())
+	if !ok {
+		log.V(1).Info("VGR does not have owner labels, skipping")
+		return req
+	}
+
+	// Fetch the VRG using the owner labels
+	vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
+	vrgNamespacedName := types.NamespacedName{
+		Namespace: ownerNamespace,
+		Name:      ownerName,
+	}
+
+	if err := r.Client.Get(context.TODO(), vrgNamespacedName, vrg); err != nil {
+		if k8serrors.IsNotFound(err) {
+			log.V(1).Info("VRG not found for VGR", "vrg", vrgNamespacedName)
+		} else {
+			log.Error(err, "Failed to get VRG for VGR", "vrg", vrgNamespacedName)
+		}
+
+		return req
+	}
+
+	// Compare VGR's LastSyncTime with VRG's LastGroupSyncTime
+	// If they differ, enqueue the VRG for reconciliation
+	if !reflect.DeepEqual(vgr.Status.LastSyncTime, vrg.Status.LastGroupSyncTime) {
+		req = append(req, reconcile.Request{
+			NamespacedName: vrgNamespacedName,
+		})
+
+		log.Info("Enqueuing VRG for offloaded VGR sync time change",
+			"vrg", vrgNamespacedName,
+			"vgrLastSyncTime", vgr.Status.LastSyncTime,
+			"vrgLastGroupSyncTime", vrg.Status.LastGroupSyncTime)
+	}
 
 	return req
 }

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -692,6 +692,21 @@ func (v *VRGInstance) processVGRAsSecondary(vrNamespacedName types.NamespacedNam
 	return v.createOrUpdateVGR(vrNamespacedName, pvcs, volrep.Secondary, log)
 }
 
+func (v *VRGInstance) labelPVCsWithVGROwner(pvcs []*corev1.PersistentVolumeClaim, vgrName string) error {
+	for idx := range pvcs {
+		pvc := pvcs[idx]
+
+		err := rmnutil.NewResourceUpdater(pvc).
+			AddLabel("volumegroupreplication-owner", vgrName).
+			Update(v.ctx, v.reconciler.Client)
+		if err != nil {
+			return fmt.Errorf("failed to update PVC labels: %w", err)
+		}
+	}
+
+	return nil
+}
+
 //nolint:gocognit,funlen
 func (v *VRGInstance) createOrUpdateVGR(vrNamespacedName types.NamespacedName,
 	pvcs []*corev1.PersistentVolumeClaim, state volrep.ReplicationState, log logr.Logger,
@@ -699,16 +714,9 @@ func (v *VRGInstance) createOrUpdateVGR(vrNamespacedName types.NamespacedName,
 	const requeue = true
 
 	v.log.V(1).Info("create or update VGR", "state", state, "pvcs", len(pvcs))
-	// ensure PVCs have the vgr name label
-	for idx := range pvcs {
-		pvc := pvcs[idx]
 
-		err := rmnutil.NewResourceUpdater(pvc).
-			AddLabel("volumegroupreplication-owner", vrNamespacedName.Name).
-			Update(v.ctx, v.reconciler.Client)
-		if err != nil {
-			return requeue, false, fmt.Errorf("failed to update PVC labels", err)
-		}
+	if err := v.labelPVCsWithVGROwner(pvcs, vrNamespacedName.Name); err != nil {
+		return requeue, false, err
 	}
 
 	volRep := &volrep.VolumeGroupReplication{}

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -698,6 +698,19 @@ func (v *VRGInstance) createOrUpdateVGR(vrNamespacedName types.NamespacedName,
 ) (bool, bool, error) {
 	const requeue = true
 
+	v.log.V(1).Info("create or update VGR", "state", state, "pvcs", len(pvcs))
+	// ensure PVCs have the vgr name label
+	for idx := range pvcs {
+		pvc := pvcs[idx]
+
+		err := rmnutil.NewResourceUpdater(pvc).
+			AddLabel("volumegroupreplication-owner", vrNamespacedName.Name).
+			Update(v.ctx, v.reconciler.Client)
+		if err != nil {
+			return requeue, false, fmt.Errorf("failed to update PVC labels", err)
+		}
+	}
+
 	volRep := &volrep.VolumeGroupReplication{}
 
 	err := v.reconciler.Get(v.ctx, vrNamespacedName, volRep)


### PR DESCRIPTION
- Trigger VRG reconciliation on external VGR sync time changes: When a VGR with `spec.external: true` has its
  `status.lastSyncTime` updated (by an external CSI driver), the VRG controller now detects the change and enqueues a reconciliation, keeping the VRG's `lastGroupSyncTime` in sync with the VGR's reported state.
- Add PVC ownership label for VGR tracking: PVCs participating in volume group replication are now labeled with `volumegroupreplication-owner` pointing to the VGR name, establishing a trackable relationship between PVCs and their owning VGR.
- Normalize VGR names to lowercase: `CreateVGRName` and `GlobalVGRName` now lowercase their inputs before constructing the resource name, preventing case-sensitivity mismatches in Kubernetes resource lookups.

Fixes: [DFBUGS-6756](https://redhat.atlassian.net/browse/DFBUGS-6756)