### PR TITLE
DFBUGS-6865: Fix PVC orphaning during VRG deletion for subscription apps

### DIFF
--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -3199,10 +3199,11 @@ func (v *VSHandler) IsVRGInAdminNamespace() bool {
 	return v.vrgInAdminNamespace
 }
 
-func (v *VSHandler) UnprotectVolSyncPVC(pvc *corev1.PersistentVolumeClaim) error {
-	v.log.Info("Unprotecting VolSync PVC", "pvcName", pvc.GetName(), "pvcNamespace", pvc.GetNamespace())
+func (v *VSHandler) UnprotectVolSyncPVC(pvc *corev1.PersistentVolumeClaim, skipPVCDisownership bool) error {
+	v.log.Info("Unprotecting VolSync PVC", "pvcName", pvc.GetName(), "pvcNamespace", pvc.GetNamespace(),
+		"skipPVCDisownership", skipPVCDisownership)
 
-	err := v.DeleteRS(pvc.GetName(), pvc.GetNamespace(), false)
+	err := v.DeleteRS(pvc.GetName(), pvc.GetNamespace(), skipPVCDisownership)
 	if err != nil {
 		v.log.Info("Failed to delete RS", "rs name", pvc.GetName(), "error", err)
 

--- a/internal/controller/vrg_volsync.go
+++ b/internal/controller/vrg_volsync.go
@@ -883,9 +883,12 @@ func (v *VRGInstance) pvcUnprotectVolSync(pvc corev1.PersistentVolumeClaim, log 
 		}
 	}
 
-	log.Info("Unprotecting VolSync PVC", "PVC", pvc.Name)
+	// Determine if VRG is being deleted to decide whether to skip PVC disownership
+	vrgBeingDeleted := util.ResourceIsDeleted(v.instance)
+
+	log.Info("Unprotecting VolSync PVC", "PVC", pvc.Name, "vrgBeingDeleted", vrgBeingDeleted)
 	// This call is only from Primary cluster. delete ReplicationSource/CG and related resources.
-	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc); err != nil {
+	if err := v.volSyncHandler.UnprotectVolSyncPVC(&pvc, vrgBeingDeleted); err != nil {
 		log.Error(err, "Failed to unprotect VolSync PVC", "PVC", pvc.Name)
 
 		return


### PR DESCRIPTION
During VRG deletion for non-discovered apps (e.g., Subscription), all ownerReferences are removed from CephFS PVCs instead of only the VRG ownerReference. This breaks Kubernetes garbage collection. When the VolSync ReplicationSource is subsequently deleted, the PVC is not cleaned up because its ownerReference was already removed.

This commit adds a skipPVCDisownership parameter to UnprotectVolSyncPVC() that preserves the RS ownerReference when the VRG is being deleted, allowing proper garbage collection to occur.

Cherry-picked from upstream commit 53d56caf6091f553f03277d7e81234bba9aec3b2