### PR TITLE
DFBUGS-5579: Backport of upstream PR 2590, 2604, 2606

### DIFF
--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -47,6 +47,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - jobs
@@ -96,6 +106,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - groupsnapshot.storage.k8s.io

--- a/config/dr-cluster/rbac/role.yaml
+++ b/config/dr-cluster/rbac/role.yaml
@@ -49,6 +49,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
   - services
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -63,6 +63,16 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - addon.open-cluster-management.io
   resources:
   - managedclusteraddons
@@ -212,6 +222,16 @@ rules:
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - groupsnapshot.storage.k8s.io

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,6 +19,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -62,16 +73,6 @@ rules:
   - pods/exec
   verbs:
   - create
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - addon.open-cluster-management.io
   resources:

--- a/internal/controller/cephfscg/replicationgroupdestination.go
+++ b/internal/controller/cephfscg/replicationgroupdestination.go
@@ -393,12 +393,16 @@ func (m *rgdMachine) CreateReplicationDestinations(
 // getMoverConfig maps the MoverConfig defined in the ReplicationDestination (RD) spec
 // into a VolSync MoverConfig
 func getMoverConfig(rdSpec ramendrv1alpha1.VolSyncReplicationDestinationSpec) volsyncv1alpha1.MoverConfig {
-	if rdSpec.MoverConfig == nil {
-		return volsyncv1alpha1.MoverConfig{}
+	mc := volsyncv1alpha1.MoverConfig{
+		MoverPodLabels: map[string]string{
+			util.CreatedByRamenLabel: "true",
+		},
 	}
 
-	return volsyncv1alpha1.MoverConfig{
-		MoverSecurityContext: rdSpec.MoverConfig.MoverSecurityContext,
-		MoverServiceAccount:  rdSpec.MoverConfig.MoverServiceAccount,
+	if rdSpec.MoverConfig != nil {
+		mc.MoverSecurityContext = rdSpec.MoverConfig.MoverSecurityContext
+		mc.MoverServiceAccount = rdSpec.MoverConfig.MoverServiceAccount
 	}
+
+	return mc
 }

--- a/internal/controller/cephfscg/volumegroupsourcehandler.go
+++ b/internal/controller/cephfscg/volumegroupsourcehandler.go
@@ -527,11 +527,15 @@ func (h *volumeGroupSourceHandler) CreateOrUpdateReplicationSourceForRestoredPVC
 			}
 
 			moverConfigVal := util.GetRSMoverConfig(originalPVCName, replicationSourceNamespace, vrg.Spec.VolSync.MoverConfig)
+			replicationSource.Spec.RsyncTLS.MoverConfig = volsyncv1alpha1.MoverConfig{
+				MoverPodLabels: map[string]string{
+					util.CreatedByRamenLabel: "true",
+				},
+			}
+
 			if moverConfigVal != nil {
-				replicationSource.Spec.RsyncTLS.MoverConfig = volsyncv1alpha1.MoverConfig{
-					MoverSecurityContext: moverConfigVal.MoverSecurityContext,
-					MoverServiceAccount:  moverConfigVal.MoverServiceAccount,
-				}
+				replicationSource.Spec.RsyncTLS.MoverConfig.MoverSecurityContext = moverConfigVal.MoverSecurityContext
+				replicationSource.Spec.RsyncTLS.MoverConfig.MoverServiceAccount = moverConfigVal.MoverServiceAccount
 			}
 
 			return nil

--- a/internal/controller/drcluster_mmode.go
+++ b/internal/controller/drcluster_mmode.go
@@ -179,6 +179,8 @@ func (u *drclusterInstance) activateRegionalFailoverPrequisite(identifier ramen.
 		},
 	}
 
+	util.AddLabel(&mMode, util.CreatedByRamenLabel, "true")
+
 	annotations := make(map[string]string)
 	annotations[DRClusterNameAnnotation] = u.object.GetName()
 

--- a/internal/controller/drclusters.go
+++ b/internal/controller/drclusters.go
@@ -96,6 +96,7 @@ var olmClusterRole = &rbacv1.ClusterRole{
 		Name: "open-cluster-management:klusterlet-work-sa:agent:olm-edit",
 		Labels: map[string]string{
 			util.ClusterRoleAggregateLabel: "true",
+			util.CreatedByRamenLabel:       "true",
 		},
 	},
 	Rules: []rbacv1.PolicyRule{
@@ -140,8 +141,14 @@ func objectsToDeploy(hubOperatorRamenConfig *rmn.RamenConfig) ([]interface{}, er
 
 func operatorGroup(namespaceName string) *operatorsv1.OperatorGroup {
 	return &operatorsv1.OperatorGroup{
-		TypeMeta:   metav1.TypeMeta{Kind: "OperatorGroup", APIVersion: "operators.coreos.com/v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "ramen-operator-group", Namespace: namespaceName},
+		TypeMeta: metav1.TypeMeta{Kind: "OperatorGroup", APIVersion: "operators.coreos.com/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ramen-operator-group",
+			Namespace: namespaceName,
+			Labels: map[string]string{
+				util.CreatedByRamenLabel: "true",
+			},
+		},
 	}
 }
 
@@ -154,8 +161,14 @@ func subscription(
 	clusterServiceVersionName string,
 ) *operatorsv1alpha1.Subscription {
 	return &operatorsv1alpha1.Subscription{
-		TypeMeta:   metav1.TypeMeta{Kind: "Subscription", APIVersion: "operators.coreos.com/v1alpha1"},
-		ObjectMeta: metav1.ObjectMeta{Name: "ramen-dr-cluster-subscription", Namespace: namespaceName},
+		TypeMeta: metav1.TypeMeta{Kind: "Subscription", APIVersion: "operators.coreos.com/v1alpha1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ramen-dr-cluster-subscription",
+			Namespace: namespaceName,
+			Labels: map[string]string{
+				util.CreatedByRamenLabel: "true",
+			},
+		},
 		Spec: &operatorsv1alpha1.SubscriptionSpec{
 			CatalogSource:          catalogSourceName,
 			CatalogSourceNamespace: catalogSourceNamespaceName,

--- a/internal/controller/drplacementcontrol_controller.go
+++ b/internal/controller/drplacementcontrol_controller.go
@@ -1325,13 +1325,13 @@ func (r *DRPlacementControlReconciler) clonePlacementRule(ctx context.Context,
 
 	clonedPlRule := &plrv1.PlacementRule{}
 
-	rmnutil.AddLabel(clonedPlRule, rmnutil.CreatedByRamenLabel, "true")
-
 	userPlRule.DeepCopyInto(clonedPlRule)
 
 	clonedPlRule.Name = clonedPlRuleName
 	clonedPlRule.ResourceVersion = ""
 	clonedPlRule.Spec.SchedulerName = ""
+
+	rmnutil.AddLabel(clonedPlRule, rmnutil.CreatedByRamenLabel, "true")
 
 	err := r.addClusterPeersToPlacementRule(drPolicy, clonedPlRule, log)
 	if err != nil {

--- a/internal/controller/kubeobjects/velero/requests.go
+++ b/internal/controller/kubeobjects/velero/requests.go
@@ -724,7 +724,7 @@ func backupRequest(namespaceName, name string, spec velero.BackupSpec,
 	labels map[string]string,
 	annotations map[string]string,
 ) *velero.Backup {
-	return &velero.Backup{
+	backup := &velero.Backup{
 		TypeMeta: backupTypeMeta(),
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   namespaceName,
@@ -734,6 +734,10 @@ func backupRequest(namespaceName, name string, spec velero.BackupSpec,
 		},
 		Spec: spec,
 	}
+
+	util.AddLabel(backup, util.CreatedByRamenLabel, "true")
+
+	return backup
 }
 
 func restore(
@@ -750,7 +754,7 @@ func restore(
 		includeClusterResources = &falseValue
 	}
 
-	return &velero.Restore{
+	restoreObj := &velero.Restore{
 		TypeMeta: restoreTypeMeta(),
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: requestNamespaceName,
@@ -772,6 +776,10 @@ func restore(
 			// TODO: preserveNodePorts?
 		},
 	}
+
+	util.AddLabel(restoreObj, util.CreatedByRamenLabel, "true")
+
+	return restoreObj
 }
 
 func backupStatusLog(backup *velero.Backup, log logr.Logger) {

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -412,19 +412,20 @@ func ConfigMapNew(
 		return nil, fmt.Errorf("config map yaml marshal %w", err)
 	}
 
-	return &corev1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespaceName,
-			Labels: map[string]string{
-				rmnutil.CreatedByRamenLabel: "true",
-			},
 		},
 		Data: map[string]string{
 			ConfigMapRamenConfigKeyName: string(ramenConfigYaml),
 		},
-	}, nil
+	}
+
+	rmnutil.AddLabel(cm, rmnutil.CreatedByRamenLabel, "true")
+
+	return cm, nil
 }
 
 func ConfigMapGet(

--- a/internal/controller/ramenconfig.go
+++ b/internal/controller/ramenconfig.go
@@ -25,6 +25,7 @@ import (
 
 	ramendrv1alpha1 "github.com/ramendr/ramen/api/v1alpha1"
 	rameninternalconfig "github.com/ramendr/ramen/internal/config"
+	rmnutil "github.com/ramendr/ramen/internal/controller/util"
 )
 
 const (
@@ -416,6 +417,9 @@ func ConfigMapNew(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespaceName,
+			Labels: map[string]string{
+				rmnutil.CreatedByRamenLabel: "true",
+			},
 		},
 		Data: map[string]string{
 			ConfigMapRamenConfigKeyName: string(ramenConfigYaml),

--- a/internal/controller/util/mw_util.go
+++ b/internal/controller/util/mw_util.go
@@ -390,8 +390,13 @@ func (mwu *MWUtil) CreateOrUpdateNamespaceManifest(
 
 func Namespace(name string) *corev1.Namespace {
 	return &corev1.Namespace{
-		TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				CreatedByRamenLabel: "true",
+			},
+		},
 	}
 }
 
@@ -429,6 +434,8 @@ func prepareRecipeForMW(recipe *recipev1.Recipe) *recipev1.Recipe {
 		ObjectMeta: ObjectMetaEmbedded(&recipe.ObjectMeta),
 	}
 	recipeCopy.Spec = recipe.Spec
+
+	AddLabel(recipeCopy, CreatedByRamenLabel, "true")
 
 	return recipeCopy
 }
@@ -537,6 +544,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:volrepgroup-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -554,6 +562,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:mmode-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -571,6 +580,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:drclusterconfig-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -588,6 +598,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:networkfence-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{
@@ -605,6 +616,7 @@ var (
 			Name: "open-cluster-management:klusterlet-work-sa:agent:recipe-edit",
 			Labels: map[string]string{
 				ClusterRoleAggregateLabel: "true",
+				CreatedByRamenLabel:       "true",
 			},
 		},
 		Rules: []rbacv1.PolicyRule{

--- a/internal/controller/util/secrets_util.go
+++ b/internal/controller/util/secrets_util.go
@@ -335,7 +335,7 @@ func newVeleroSecret(s3SecretRef corev1.SecretReference, fromNS, veleroNS, keyNa
 }
 
 func newConfigurationPolicy(name string, object *runtime.RawExtension) *cpcv1.ConfigurationPolicy {
-	return &cpcv1.ConfigurationPolicy{
+	cp := &cpcv1.ConfigurationPolicy{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigurationPolicy",
 			APIVersion: "policy.open-cluster-management.io/v1",
@@ -354,6 +354,10 @@ func newConfigurationPolicy(name string, object *runtime.RawExtension) *cpcv1.Co
 			},
 		},
 	}
+
+	AddLabel(cp, CreatedByRamenLabel, "true")
+
+	return cp
 }
 
 func newPolicy(name, namespace, triggerValue string, object runtime.RawExtension) *gppv1.Policy {

--- a/internal/controller/volsync/secret_propagator.go
+++ b/internal/controller/volsync/secret_propagator.go
@@ -216,6 +216,9 @@ func (sp *secretPropagator) getEmbeddedConfigPolicy() (*cfgpolicyv1.Configuratio
 		"metadata": map[string]interface{}{
 			"name":      sp.DestSecretName,
 			"namespace": sp.DestSecretNamespace,
+			"labels": map[string]string{
+				util.CreatedByRamenLabel: "true",
+			},
 		},
 		"type": "Opaque",
 		"data": secretData,
@@ -249,6 +252,8 @@ func (sp *secretPropagator) getEmbeddedConfigPolicy() (*cfgpolicyv1.Configuratio
 			Severity:          "low",
 		},
 	}
+
+	util.AddLabel(embeddedConfigPolicy, util.CreatedByRamenLabel, "true")
 
 	return embeddedConfigPolicy, nil
 }

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -1886,10 +1886,24 @@ func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
 	}
 
 	err = util.NewResourceUpdater(svc).
-		AddLabel(util.CreatedByRamenLabel, "true").
+		AddLabel(util.CreatedByRamenLabel, "transitive").
 		Update(v.ctx, v.client)
 	if err != nil {
 		v.log.V(1).Info("Failed to label VolSync Service", "serviceName", serviceName, "error", err)
+	}
+
+	ep := &corev1.Endpoints{}
+
+	err = v.client.Get(v.ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, ep)
+	if err != nil {
+		v.log.V(1).Info("VolSync Endpoints not found yet, skipping label", "serviceName", serviceName)
+	} else {
+		err = util.NewResourceUpdater(ep).
+			AddLabel(util.CreatedByRamenLabel, "transitive").
+			Update(v.ctx, v.client)
+		if err != nil {
+			v.log.V(1).Info("Failed to label VolSync Endpoints", "serviceName", serviceName, "error", err)
+		}
 	}
 
 	epSliceList := &discoveryv1.EndpointSliceList{}
@@ -1906,7 +1920,7 @@ func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
 
 	for i := range epSliceList.Items {
 		err = util.NewResourceUpdater(&epSliceList.Items[i]).
-			AddLabel(util.CreatedByRamenLabel, "true").
+			AddLabel(util.CreatedByRamenLabel, "transitive").
 			Update(v.ctx, v.client)
 		if err != nil {
 			v.log.V(1).Info("Failed to label VolSync EndpointSlice",

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -144,6 +144,21 @@ func (v *VSHandler) SetWorkloadStatus(status string) {
 	v.workloadStatus = status
 }
 
+func buildMoverConfig(moverConfigSpec *ramendrv1alpha1.MoverConfig) volsyncv1alpha1.MoverConfig {
+	mc := volsyncv1alpha1.MoverConfig{
+		MoverPodLabels: map[string]string{
+			util.CreatedByRamenLabel: "true",
+		},
+	}
+
+	if moverConfigSpec != nil {
+		mc.MoverSecurityContext = moverConfigSpec.MoverSecurityContext
+		mc.MoverServiceAccount = moverConfigSpec.MoverServiceAccount
+	}
+
+	return mc
+}
+
 // returns replication destination only if create/update is successful and the RD is considered available.
 // Callers should assume getting a nil replication destination back means they should retry/requeue.
 //
@@ -398,14 +413,7 @@ func (v *VSHandler) createOrUpdateRD(
 		util.AddAnnotation(rd, OwnerNameAnnotation, v.owner.GetName())
 		util.AddAnnotation(rd, OwnerNamespaceAnnotation, v.owner.GetNamespace())
 
-		moverConfig := volsyncv1alpha1.MoverConfig{}
-
-		if moverConfigSpec != nil {
-			moverConfig = volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
 			params := map[string]string{
@@ -674,13 +682,7 @@ func (v *VSHandler) createOrUpdateRS(rsSpec ramendrv1alpha1.VolSyncReplicationSo
 			return err
 		}
 
-		moverConfig := &volsyncv1alpha1.MoverConfig{}
-		if moverConfigSpec != nil {
-			moverConfig = &volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		if util.IsDiffSyncEnabled(v.owner.GetAnnotations()) {
 			rs.Spec.External = &volsyncv1alpha1.ReplicationSourceExternalSpec{
@@ -708,7 +710,7 @@ func (v *VSHandler) createOrUpdateRS(rsSpec ramendrv1alpha1.VolSyncReplicationSo
 					StorageClassName:        rsSpec.ProtectedPVC.StorageClassName,
 					AccessModes:             rsSpec.ProtectedPVC.AccessModes,
 				},
-				MoverConfig: *moverConfig,
+				MoverConfig: moverConfig,
 			}
 		}
 
@@ -2702,13 +2704,7 @@ func (v *VSHandler) reconcileLocalRD(rdSpec ramendrv1alpha1.VolSyncReplicationDe
 			pvcAccessModes = rdSpec.ProtectedPVC.AccessModes
 		}
 
-		moverConfig := &volsyncv1alpha1.MoverConfig{}
-		if moverConfigSpec != nil {
-			moverConfig = &volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		lrd.Spec.External = nil
 		lrd.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationDestinationRsyncTLSSpec{
@@ -2722,7 +2718,7 @@ func (v *VSHandler) reconcileLocalRD(rdSpec ramendrv1alpha1.VolSyncReplicationDe
 				AccessModes:      pvcAccessModes,
 				DestinationPVC:   &rdSpec.ProtectedPVC.Name,
 			},
-			MoverConfig: *moverConfig,
+			MoverConfig: moverConfig,
 		}
 
 		return nil
@@ -2780,13 +2776,7 @@ func (v *VSHandler) reconcileLocalRS(rd *volsyncv1alpha1.ReplicationDestination,
 
 		lrs.Spec.SourcePVC = pvc.GetName()
 
-		moverConfig := &volsyncv1alpha1.MoverConfig{}
-		if moverConfigSpec != nil {
-			moverConfig = &volsyncv1alpha1.MoverConfig{
-				MoverSecurityContext: moverConfigSpec.MoverSecurityContext,
-				MoverServiceAccount:  moverConfigSpec.MoverServiceAccount,
-			}
-		}
+		moverConfig := buildMoverConfig(moverConfigSpec)
 
 		lrs.Spec.External = nil
 		lrs.Spec.RsyncTLS = &volsyncv1alpha1.ReplicationSourceRsyncTLSSpec{
@@ -2796,7 +2786,7 @@ func (v *VSHandler) reconcileLocalRS(rd *volsyncv1alpha1.ReplicationDestination,
 			ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
 				CopyMethod: volsyncv1alpha1.CopyMethodDirect,
 			},
-			MoverConfig: *moverConfig,
+			MoverConfig: moverConfig,
 		}
 
 		return nil

--- a/internal/controller/volsync/vshandler.go
+++ b/internal/controller/volsync/vshandler.go
@@ -17,6 +17,7 @@ import (
 	vgsv1beta1 "github.com/red-hat-storage/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -1869,7 +1870,49 @@ func (v *VSHandler) ReconcileServiceExportForRD(rd *volsyncv1alpha1.ReplicationD
 		return fmt.Errorf("error creating or updating ServiceExport (%w)", err)
 	}
 
+	v.ensureVolSyncServiceLabels(serviceName, rd.GetNamespace())
+
 	return nil
+}
+
+func (v *VSHandler) ensureVolSyncServiceLabels(serviceName, namespace string) {
+	svc := &corev1.Service{}
+
+	err := v.client.Get(v.ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, svc)
+	if err != nil {
+		v.log.V(1).Info("VolSync Service not found yet, skipping label", "serviceName", serviceName)
+
+		return
+	}
+
+	err = util.NewResourceUpdater(svc).
+		AddLabel(util.CreatedByRamenLabel, "true").
+		Update(v.ctx, v.client)
+	if err != nil {
+		v.log.V(1).Info("Failed to label VolSync Service", "serviceName", serviceName, "error", err)
+	}
+
+	epSliceList := &discoveryv1.EndpointSliceList{}
+
+	err = v.client.List(v.ctx, epSliceList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{"kubernetes.io/service-name": serviceName},
+	)
+	if err != nil {
+		v.log.V(1).Info("Failed to list EndpointSlices, skipping label", "serviceName", serviceName)
+
+		return
+	}
+
+	for i := range epSliceList.Items {
+		err = util.NewResourceUpdater(&epSliceList.Items[i]).
+			AddLabel(util.CreatedByRamenLabel, "true").
+			Update(v.ctx, v.client)
+		if err != nil {
+			v.log.V(1).Info("Failed to label VolSync EndpointSlice",
+				"endpointSlice", epSliceList.Items[i].Name, "error", err)
+		}
+	}
 }
 
 func (v *VSHandler) listRSByOwner(rsNamespace string) (volsyncv1alpha1.ReplicationSourceList, error) {
@@ -2269,6 +2312,7 @@ func (v *VSHandler) validateAndProtectSnapshot(
 	err = updater.AddLabel(util.VRGOwnerNameLabel, v.owner.GetName()).
 		AddLabel(util.VRGOwnerNamespaceLabel, v.owner.GetNamespace()).
 		AddLabel(VolSyncDoNotDeleteLabel, VolSyncDoNotDeleteLabelVal).
+		AddLabel(util.CreatedByRamenLabel, "true").
 		Update(v.ctx, v.client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to add owner/label to snapshot %s (%w)", volSnap.GetName(), err)

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -432,6 +432,7 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -431,6 +431,8 @@ func filterPVC(reader client.Reader, pvc *corev1.PersistentVolumeClaim, log logr
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=get;create;patch;update
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ramendr.openshift.io,resources=recipes,verbs=get;list;watch

--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -3685,8 +3685,9 @@ func (v *VRGInstance) createSnapshot(pvc *corev1.PersistentVolumeClaim, snapshot
 			Name:      snapName,
 			Namespace: pvc.Namespace,
 			Labels: map[string]string{
-				dryRunSnapshotLabel: "true",
-				dryRunVRGLabel:      v.instance.Name,
+				dryRunSnapshotLabel:         "true",
+				dryRunVRGLabel:              v.instance.Name,
+				rmnutil.CreatedByRamenLabel: "true",
 			},
 		},
 		Spec: snapv1.VolumeSnapshotSpec{


### PR DESCRIPTION
Add `ramendr.openshift.io/created-by-ramen: "true"` label to the remaining
direct resources that were missing it (Namespace, ClusterRoles via MW,
OperatorGroup, Subscription, ConfigMap, MaintenanceMode). Fix a pre-existing
bug where the label on cloned PlacementRule was set before DeepCopyInto,
causing it to be silently overwritten.

Pass `MoverPodLabels` with the CreatedByRamen label to VolSync MoverConfig so
transitive mover pods created by VolSync also carry the label. Introduce a
shared `buildMoverConfig()` helper in vshandler.go that replaces 4 inline
MoverConfig construction sites, and update the CephFS getMoverConfig() and
volumegroupsourcehandler similarly.

Add the CreatedByRamen label to Velero Backup and Restore objects which were
previously missing it.

git cherry-pick -x 527ecddb 4ad5a603 3d56b2b2 93f016ef b32abe11