### PR TITLE
[release-4.17] Bump go (stdlib) from 1.22.7 to 1.22.12

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,11 +2,12 @@ module github.com/ramendr/ramen/api
 
 go 1.22.0
 
-toolchain go1.22.7
+toolchain go1.22.12
 
 require (
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
+	k8s.io/component-base v0.28.3
 	sigs.k8s.io/controller-runtime v0.16.3
 )
 
@@ -21,7 +22,6 @@ require (
 	golang.org/x/text v0.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/component-base v0.28.3 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/ramendr/ramen/e2e
 
 go 1.22.0
 
-toolchain go1.22.7
+toolchain go1.22.12
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/ramendr/ramen
 
 go 1.22.5
 
-toolchain go1.22.7
+toolchain go1.22.12
 
 // This replace should always be here for ease of development.
 replace github.com/ramendr/ramen/api => ./api


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.22.7` → `1.22.12` (in `api/go.mod`)
- **go (stdlib)**: `1.22.7` → `1.22.12` (in `e2e/go.mod`)
- **go (stdlib)**: `1.22.7` → `1.22.12` (in `go.mod`)
