### PR TITLE
[release-4.21] Bump go (stdlib) from 1.24.5 to 1.24.11

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@ module github.com/ramendr/ramen/api
 go 1.24.0
 
 // Recommended version: latest go 1.24 release.
-toolchain go1.24.5
+toolchain go1.24.11
 
 require (
 	k8s.io/api v0.33.2

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -4,7 +4,7 @@ module github.com/ramendr/ramen/e2e
 go 1.24.0
 
 // Recommended version: latest go 1.24 release.
-toolchain go1.24.5
+toolchain go1.24.11
 
 require (
 	github.com/aymanbagabas/go-udiff v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/ramendr/ramen
 go 1.24.0
 
 // Recommended version: latest go 1.24 release.
-toolchain go1.24.5
+toolchain go1.24.11
 
 // This replace should always be here for ease of development.
 replace github.com/ramendr/ramen/api => ./api


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.5` → `1.24.11` (in `api/go.mod`)
- **go (stdlib)**: `1.24.5` → `1.24.11` (in `e2e/go.mod`)
- **go (stdlib)**: `1.24.5` → `1.24.11` (in `go.mod`)
