### PR TITLE
DFBUGS-7975: Restore PV volume handle from annotation

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2868,6 +2868,17 @@ func (v *VRGInstance) cleanupPVForRestore(pv *corev1.PersistentVolume) error {
 		pv.Spec.ClaimRef.APIVersion = ""
 	}
 
+	// If the PV was annotated with a destination volume handle during S3 upload,
+	// replace the CSI volumeHandle so the PV references the correct volume on
+	// this (destination) cluster.
+	if pv.Spec.CSI != nil && pv.Annotations != nil {
+		if destHandle, ok := pv.Annotations[destinationVolumeHandleAnnotation]; ok && destHandle != "" {
+			v.log.V(1).Info("Set PV volume handle from destination handle", "PV", pv.Name, "handle", destHandle)
+			pv.Spec.CSI.VolumeHandle = destHandle
+			delete(pv.Annotations, destinationVolumeHandleAnnotation)
+		}
+	}
+
 	return v.processPVSecrets(pv)
 }
 


### PR DESCRIPTION
When restoring a PV, use the peer volume handle annotation to set the volume handle if it is present.

This restores the missing logic from the original volume group implementation.


(cherry picked from commit 8539a3642b6ec15656e625f0357acba662350d84)