### PR TITLE
DFBUGS-9019: re-upload PV to S3 after destination volume handle change

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -818,6 +818,9 @@ func (v *VRGInstance) destinationInfoAvailableOrSkip(
 
 // applyDestinationVolumeHandleToPV sets destinationVolumeHandleAnnotation on pv when it differs
 // and persists the change. destinationVolumeHandle must be non-empty.
+// Clearing the archived annotation forces a re-upload to S3 in the same reconcile:
+// annotation-only PV updates do not bump Generation, so isArchivedAlready would otherwise
+// skip upload of the updated PV.
 func (v *VRGInstance) applyDestinationVolumeHandleToPV(
 	pv *corev1.PersistentVolume, destinationVolumeHandle string,
 ) error {
@@ -830,6 +833,7 @@ func (v *VRGInstance) applyDestinationVolumeHandleToPV(
 	}
 
 	pv.Annotations[destinationVolumeHandleAnnotation] = destinationVolumeHandle
+	delete(pv.Annotations, pvcVRAnnotationArchivedKey)
 	v.log.Info(fmt.Sprintf("annotated PV %s with DestinationVolumeID %s", pv.Name, destinationVolumeHandle))
 
 	if err := v.reconciler.Update(v.ctx, pv); err != nil {


### PR DESCRIPTION
Clear the archived annotation when annotating the PV so isArchivedAlready does not skip upload; annotation-only updates do not bump Generation.


(cherry picked from commit 7a6e622cd8807c2e4a9f7c403de8d8e7455c038f)