### PR TITLE
DFBUGS-9002: vrg: Prevent stale DataReady condition for global VGR apps

### DIFF
--- a/internal/controller/vrg_volrep.go
+++ b/internal/controller/vrg_volrep.go
@@ -2917,7 +2917,7 @@ func cleanupPVCForRestore(pvc *corev1.PersistentVolumeClaim) error {
 //	VRG.conditions.Available.Status = false
 //	VRG.conditions.Available.Reason = Progressing
 //
-//nolint:funlen
+//nolint:funlen,gocognit,cyclop
 func (v *VRGInstance) aggregateVolRepDataReadyCondition() *metav1.Condition {
 	if len(v.volRepPVCs) == 0 {
 		return v.vrgReadyStatus(VRGConditionReasonUnused)
@@ -2941,6 +2941,18 @@ func (v *VRGInstance) aggregateVolRepDataReadyCondition() *metav1.Condition {
 			// why treat it as an error instead of progressing?
 			v.log.Info(fmt.Sprintf("Failed to find condition %s for vrg %s/%s", VRGConditionTypeDataReady,
 				v.instance.Name, v.instance.Namespace))
+
+			break
+		}
+
+		if v.hasGlobalVGRLabel() && condition.ObservedGeneration != v.instance.Generation {
+			vrgReady = false
+			vrgProgressing = true
+
+			v.log.Info("Stale DataReady condition detected for PVC, treating as progressing",
+				"protectedPVC", protectedPVC.Name,
+				"conditionGeneration", condition.ObservedGeneration,
+				"vrgGeneration", v.instance.Generation)
 
 			break
 		}


### PR DESCRIPTION
When a VRG's spec changes (e.g., primary→secondary), the consensus gate may block reconciliation, leaving per-PVC DataReady conditions from the previous generation.
aggregateVolRepDataReadyCondition() would launder
these stale conditions into the VRG-level DataReady with the current generation, causing the VRG to falsely report Secondary state while workloads are still active on the source cluster.

Add a generation check for global VGR apps: if a per-PVC DataReady condition's observedGeneration doesn't match the current VRG generation, treat it as progressing rather than ready. This prevents DRPC from prematurely marking failover/relocate as Completed.

(cherry picked from commit ab2cee43)

