### PR TITLE
DFBUGS-9561: global-vgr: Gate secondary transition on cross-VRG PVC readiness

### DIFF
--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -60,6 +60,10 @@ const (
 	// reached the desired replication state.
 	VRGConditionTypeGlobalState = "GlobalState"
 
+	// Indicates whether this VRG's PVCs are not in use, allowing the shared
+	// global VGR to transition to secondary. Only applicable for global VGR VRGs.
+	VRGConditionTypeGlobalSecondary = "GlobalSecondary"
+
 	// Indicates the status of hook execution in recipes.
 	// This condition helps identify hook failures separately from other kube object protection issues.
 	VRGConditionTypeHooksReady = "HooksReady"
@@ -107,8 +111,13 @@ const (
 	VRGConditionReasonAutoCleanupNotFeasible = "NotFeasible"
 	VRGConditionReasonAutoCleanupCompleted   = "Completed"
 
+	// Global consensus reasons for GlobalState condition.
 	ConditionReasonConsensusReached    = "ConsensusReached"
 	ConditionReasonConsensusNotReached = "ConsensusNotReached"
+
+	// Global secondary transition reasons for GlobalSecondary condition.
+	VRGConditionReasonPVCsNotInUse = "PVCsNotInUse"
+	VRGConditionReasonPVCsInUse    = "PVCsInUse"
 
 	// Hook-specific condition reasons for better visibility of hook failures
 	VRGConditionReasonHookExecuted = "HookExecuted"

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -1475,6 +1475,12 @@ func (v *VRGInstance) processAsPrimary() ctrl.Result {
 
 	defer v.log.Info("Exiting processing VolumeReplicationGroup")
 
+	// Reset global VGR secondary readiness condition; only meaningful when Secondary.
+	if v.hasGlobalVGRLabel() {
+		v.setGlobalSecondaryCondition(metav1.ConditionTrue,
+			VRGConditionReasonUnused, "Not applicable when Primary")
+	}
+
 	v.resetKubeObjectsCaptureStatusIfRequired()
 
 	if v.shouldRestoreClusterData() {

--- a/internal/controller/vrg_volgrouprep.go
+++ b/internal/controller/vrg_volgrouprep.go
@@ -93,10 +93,21 @@ func (v *VRGInstance) reconcileVolGroupRepsAsPrimary(groupPVCs map[types.Namespa
 func (v *VRGInstance) reconcileVolGroupRepsAsSecondary(requeue *bool,
 	groupPVCs map[types.NamespacedName][]*corev1.PersistentVolumeClaim,
 ) {
-	if v.hasGlobalVGRLabel() && !v.isGlobalStateInConsensus() {
-		*requeue = true
+	if v.hasGlobalVGRLabel() {
+		// On steady-state secondary, no PVCs match the VRG selector.
+		// Signal readiness so siblings don't wait on this VRG.
+		if len(groupPVCs) == 0 {
+			v.setGlobalSecondaryCondition(metav1.ConditionTrue,
+				VRGConditionReasonPVCsNotInUse, "PVCs are not in use")
 
-		return
+			return
+		}
+
+		if !v.isGlobalStateInConsensus() {
+			*requeue = true
+
+			return
+		}
 	}
 
 	for vgrNamespacedName, pvcs := range groupPVCs {
@@ -134,8 +145,24 @@ func (v *VRGInstance) reconcileVGRAsSecondary(vrNamespacedName types.NamespacedN
 		skip    bool = true
 	)
 
+	isGlobal := v.hasGlobalVGRLabel()
+
 	for idx := range pvcs {
 		if !v.isPVCReadyForSecondary(pvcs[idx], log) {
+			if isGlobal {
+				v.setGlobalSecondaryCondition(metav1.ConditionFalse,
+					VRGConditionReasonPVCsInUse, "PVCs are still in use")
+			}
+
+			return requeue, false, skip
+		}
+	}
+
+	if isGlobal {
+		v.setGlobalSecondaryCondition(metav1.ConditionTrue,
+			VRGConditionReasonPVCsNotInUse, "PVCs are not in use")
+
+		if !v.areSiblingVRGsReadyForGlobalSecondary(log) {
 			return requeue, false, skip
 		}
 	}

--- a/internal/controller/vrg_volgrouprep_global.go
+++ b/internal/controller/vrg_volgrouprep_global.go
@@ -154,6 +154,60 @@ func (v *VRGInstance) isGlobalStateInConsensus() bool {
 	return true
 }
 
+// areSiblingVRGsReadyForGlobalSecondary checks that all sibling VRGs sharing
+// the same global VGR label have signaled their PVCs are ready for the global
+// VGR to transition to secondary. This prevents one VRG from flipping the shared
+// VGR while another VRG's workloads are still active.
+func (v *VRGInstance) areSiblingVRGsReadyForGlobalSecondary(log logr.Logger) bool {
+	vgrLabel := v.globalVGRLabel()
+
+	var vrgs ramendrv1alpha1.VolumeReplicationGroupList
+	if err := v.reconciler.List(v.ctx, &vrgs,
+		client.MatchingLabels{GlobalVGRLabel: vgrLabel},
+	); err != nil {
+		log.Error(err, "Failed to list sibling VRGs for global VGR secondary readiness")
+
+		return false
+	}
+
+	var pending []string
+
+	for idx := range vrgs.Items {
+		sibling := &vrgs.Items[idx]
+		if sibling.Name == v.instance.Name && sibling.Namespace == v.instance.Namespace {
+			continue
+		}
+
+		if rmnutil.ResourceIsDeleted(sibling) {
+			continue // Sibling is being torn down; don't gate on it.
+		}
+
+		if !v.isSiblingReadyForGlobalSecondary(sibling) {
+			pending = append(pending, sibling.Namespace+"/"+sibling.Name)
+		}
+	}
+
+	if len(pending) > 0 {
+		log.Info("Waiting for sibling VRGs to release PVCs before flipping global VGR",
+			"pending", strings.Join(pending, ", "))
+
+		return false
+	}
+
+	log.Info("All sibling VRGs ready for global VGR secondary transition")
+
+	return true
+}
+
+func (v *VRGInstance) isSiblingReadyForGlobalSecondary(sibling *ramendrv1alpha1.VolumeReplicationGroup) bool {
+	cond := rmnutil.FindCondition(sibling.Status.Conditions, VRGConditionTypeGlobalSecondary)
+
+	return cond != nil &&
+		cond.Status == metav1.ConditionTrue &&
+		cond.Reason != VRGConditionReasonUnused &&
+		cond.ObservedGeneration == sibling.Generation
+}
+
 // isGlobalDeleteInConsensus checks that all VRGs sharing the same global VGR label
 // have a deletion timestamp. The global VGR is only deleted when all its VRGs are removed.
 func (v *VRGInstance) isGlobalDeleteInConsensus(log logr.Logger) bool {
@@ -203,6 +257,18 @@ func (v *VRGInstance) deleteGlobalVGR() bool {
 func (v *VRGInstance) setGlobalStateCondition(status metav1.ConditionStatus, reason, message string) {
 	rmnutil.SetStatusCondition(&v.instance.Status.Conditions, metav1.Condition{
 		Type:               VRGConditionTypeGlobalState,
+		Status:             status,
+		ObservedGeneration: v.instance.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+// setGlobalSecondaryCondition updates the condition indicating whether
+// this VRG's PVCs are not in use, allowing the shared global VGR to transition to secondary.
+func (v *VRGInstance) setGlobalSecondaryCondition(status metav1.ConditionStatus, reason, message string) {
+	rmnutil.SetStatusCondition(&v.instance.Status.Conditions, metav1.Condition{
+		Type:               VRGConditionTypeGlobalSecondary,
 		Status:             status,
 		ObservedGeneration: v.instance.Generation,
 		Reason:             reason,

--- a/internal/controller/vrg_volgrouprep_global_test.go
+++ b/internal/controller/vrg_volgrouprep_global_test.go
@@ -120,23 +120,7 @@ var _ = Describe("GlobalVGR deletion consensus", Ordered, func() {
 
 	BeforeAll(func() {
 		g = newGlobalVGRTest()
-		createGlobalSC(g.scName, g.replicationID)
-		createGlobalVGRC(g.vgrcName, g.replicationID)
-		g.peerClass = buildGlobalPeerClass(g.replicationID, g.scName)
-
-		namespaceCreate(g.vrgA.namespace)
-		createBoundPVCAndPV(g.vrgA.namespace, g.scName, g.vrgA.vrgName)
-		createGlobalVRG(g.vrgA.vrgName, g.vrgA.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
-
-		namespaceCreate(g.vrgB.namespace)
-		createBoundPVCAndPV(g.vrgB.namespace, g.scName, g.vrgB.vrgName)
-		createGlobalVRG(g.vrgB.vrgName, g.vrgB.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
-
-		g.waitForGlobalVGRLabel(g.vrgA)
-		g.waitForGlobalVGRLabel(g.vrgB)
-		g.updateGlobalVGRStatus(volrep.PrimaryState)
-		g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
-		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
+		g.setupTwoVRGsAsPrimary()
 	})
 
 	It("keeps VGR when only one VRG is deleted", func() {
@@ -212,7 +196,120 @@ var _ = Describe("GlobalVGR mixed GroupReplicationID", Ordered, func() {
 	AfterAll(func() { g.cleanupAll() })
 })
 
+var _ = Describe("GlobalVGR secondary transition gating", Ordered, func() {
+	var g *globalVGRTest
+
+	var pod *corev1.Pod
+
+	BeforeAll(func() {
+		g = newGlobalVGRTest()
+		g.setupTwoVRGsAsPrimary()
+	})
+
+	It("sets GlobalSecondary to Unused when VRGs are Primary", func() {
+		g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonUnused)
+		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonUnused)
+	})
+
+	It("blocks VGR flip when VRG-B PVC is in use by a pod", func() {
+		pvcName := fmt.Sprintf("pvc-%s", g.vrgB.vrgName)
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-blocking-pod-",
+				Namespace:    g.vrgB.namespace,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "c1", Image: "busybox"},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "vol1",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), pod)).To(Succeed())
+
+		// Ensure pod is visible in the cache
+		Eventually(func() error {
+			return k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pod), pod)
+		}, vrgtimeout, vrginterval).Should(Succeed())
+
+		g.updateVRGSpecWithAction(g.vrgA, ramendrv1alpha1.Secondary, ramendrv1alpha1.VRGActionFailover)
+		g.updateVRGSpecWithAction(g.vrgB, ramendrv1alpha1.Secondary, ramendrv1alpha1.VRGActionFailover)
+
+		// VRG-A PVCs are not in use
+		g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonPVCsNotInUse)
+
+		// VRG-B PVCs are in use by pod
+		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionFalse, vrgController.VRGConditionReasonPVCsInUse)
+
+		// VGR should NOT have flipped to secondary
+		g.verifyGlobalVGRReplicationState(volrep.Primary)
+	})
+
+	It("allows VGR flip after pod is deleted", func() {
+		Expect(k8sClient.Delete(context.TODO(), pod)).To(Succeed())
+
+		// Wait for pod to disappear from cache
+		Eventually(func() bool {
+			err := k8sClient.Get(context.TODO(), client.ObjectKeyFromObject(pod), &corev1.Pod{})
+
+			return errors.IsNotFound(err)
+		}, vrgtimeout, vrginterval).Should(BeTrue())
+
+		// VRG-B should now report PVCsNotInUse
+		g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeGlobalSecondary,
+			metav1.ConditionTrue, vrgController.VRGConditionReasonPVCsNotInUse)
+
+		// VGR should transition to secondary
+		g.verifyGlobalVGRReplicationState(volrep.Secondary)
+	})
+
+	AfterAll(func() {
+		if pod != nil {
+			deleteIgnoreNotFound(pod)
+		}
+
+		g.deleteVRG(g.vrgA)
+		g.deleteVRG(g.vrgB)
+		g.verifyVRGDeleted(g.vrgA)
+		g.verifyVRGDeleted(g.vrgB)
+		g.cleanupAll()
+	})
+})
+
 // --- Test helpers ---
+
+func (g *globalVGRTest) setupTwoVRGsAsPrimary() {
+	createGlobalSC(g.scName, g.replicationID)
+	createGlobalVGRC(g.vgrcName, g.replicationID)
+	g.peerClass = buildGlobalPeerClass(g.replicationID, g.scName)
+
+	namespaceCreate(g.vrgA.namespace)
+	createBoundPVCAndPV(g.vrgA.namespace, g.scName, g.vrgA.vrgName)
+	createGlobalVRG(g.vrgA.vrgName, g.vrgA.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
+
+	namespaceCreate(g.vrgB.namespace)
+	createBoundPVCAndPV(g.vrgB.namespace, g.scName, g.vrgB.vrgName)
+	createGlobalVRG(g.vrgB.vrgName, g.vrgB.namespace, []ramendrv1alpha1.PeerClass{g.peerClass})
+
+	g.waitForGlobalVGRLabel(g.vrgA)
+	g.waitForGlobalVGRLabel(g.vrgB)
+	g.updateGlobalVGRStatus(volrep.PrimaryState)
+	g.verifyVRGCondition(g.vrgA, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
+	g.verifyVRGCondition(g.vrgB, vrgController.VRGConditionTypeDataReady, metav1.ConditionTrue, "")
+}
 
 func (g *globalVGRTest) globalVGRKey() types.NamespacedName {
 	return types.NamespacedName{
@@ -361,29 +458,28 @@ func (g *globalVGRTest) verifyVRGCondition(
 ) {
 	vrgKey := types.NamespacedName{Name: inst.vrgName, Namespace: inst.namespace}
 
-	Eventually(func() metav1.ConditionStatus {
+	Eventually(func() bool {
 		vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
 		if err := apiReader.Get(context.TODO(), vrgKey, vrg); err != nil {
-			return metav1.ConditionUnknown
+			return false
 		}
 
 		cond := meta.FindStatusCondition(vrg.Status.Conditions, condType)
 		if cond == nil {
-			return metav1.ConditionUnknown
+			return false
 		}
 
-		return cond.Status
-	}, vrgtimeout, vrginterval).Should(Equal(expectedStatus),
-		"waiting for VRG %s condition %s=%s", vrgKey, condType, expectedStatus)
+		if cond.Status != expectedStatus {
+			return false
+		}
 
-	if expectedReason != "" {
-		vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
-		Expect(apiReader.Get(context.TODO(), vrgKey, vrg)).To(Succeed())
+		if expectedReason != "" && cond.Reason != expectedReason {
+			return false
+		}
 
-		cond := meta.FindStatusCondition(vrg.Status.Conditions, condType)
-		Expect(cond).NotTo(BeNil())
-		Expect(cond.Reason).To(Equal(expectedReason))
-	}
+		return true
+	}, vrgtimeout, vrginterval).Should(BeTrue(),
+		"waiting for VRG %s condition %s=%s reason=%s", vrgKey, condType, expectedStatus, expectedReason)
 }
 
 func (g *globalVGRTest) verifyVRGDeleted(inst *globalVRGInstance) {
@@ -507,4 +603,22 @@ func (g *globalVGRTest) cleanupAll() {
 	}
 
 	deleteIgnoreNotFound(&volrep.VolumeGroupReplicationClass{ObjectMeta: metav1.ObjectMeta{Name: g.vgrcName}})
+}
+
+func (g *globalVGRTest) updateVRGSpecWithAction(
+	inst *globalVRGInstance, state ramendrv1alpha1.ReplicationState, action ramendrv1alpha1.VRGAction,
+) {
+	vrgKey := types.NamespacedName{Name: inst.vrgName, Namespace: inst.namespace}
+
+	Expect(retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		vrg := &ramendrv1alpha1.VolumeReplicationGroup{}
+		if err := k8sClient.Get(context.TODO(), vrgKey, vrg); err != nil {
+			return err
+		}
+
+		vrg.Spec.ReplicationState = state
+		vrg.Spec.Action = action
+
+		return k8sClient.Update(context.TODO(), vrg)
+	})).To(Succeed())
 }


### PR DESCRIPTION
When multiple VRGs share a global VGR, the VGR transition to secondary must
wait until all VRGs confirm their PVCs are no longer in use. Without this,
a VRG that completes cleanup faster can flip the shared VGR while other
VRGs' workloads are still active on the same cluster.

Fixes: [DFBUGS-9561](https://redhat.atlassian.net/browse/DFBUGS-9561)

Cherry-picked from:
- 44ab3c470d1530cb9bb36df5cf3abc98f0d40e9f
- 39dd7171174bb3e4ea0f7052899964b812554a97