### PR TITLE
DFBUGS-9558: allow extra CIDRs in DRCluster spec

### DIFF
--- a/api/v1alpha1/drcluster_types.go
+++ b/api/v1alpha1/drcluster_types.go
@@ -59,6 +59,29 @@ const (
 	// Fencing CR to fence off this cluster
 	// has been created
 	DRClusterConditionTypeFenced = "Fenced"
+
+	// CIDRsValidated indicates the validation state of CIDRs configured in the DRCluster
+	// against CIDRs detected by the storage provisioner in DRClusterConfig StorageAccessDetails.
+	DRClusterConditionTypeCIDRsValidated = "CIDRsValidated"
+)
+
+const (
+	// CIDRsValidated condition reasons
+
+	// All detected CIDRs are configured in DRCluster and no undetected CIDRs found
+	ReasonCIDRsValidationSucceeded = "Succeeded"
+
+	// CIDRs configured in DRCluster.Spec have an invalid format.
+	ReasonInvalidCIDRsFormat = "InvalidCIDRsFormat"
+
+	// Detected CIDRs from StorageAccessDetails are not configured in DRCluster.
+	// These are required for network fencing and their absence may leave storage
+	// access paths unfenced during failover.
+	ReasonDetectedCIDRsUnconfigured = "DetectedCIDRsUnconfigured"
+
+	// Additional CIDRs configured in DRCluster are not detected by the storage provisioner
+	// in StorageAccessDetails; additional CIDRs are allowed.
+	ReasonUndetectedCIDRsFound = "UndetectedCIDRsFound"
 )
 
 type DRClusterPhase string

--- a/config/prometheus/alerts.yaml
+++ b/config/prometheus/alerts.yaml
@@ -62,7 +62,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            description: "Invalid or undetected CIDRs Specified (DRCluster: {{ $labels.obj_name }}). Inspect DRCluster status for more details."
+            description: "CIDRs validation failed: invalid format or detected CIDRs not configured (DRCluster: {{ $labels.obj_name }}). Inspect DRCluster status for more details."
             alert_type: "DisasterRecovery"
         - alert: ApplicationCleanupPending
           expr: ramen_progression_state{state="WaitOnUserToCleanUp"} == 1

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -568,7 +568,7 @@ func (u *drclusterInstance) validateCIDRsConfigured(conditions *[]metav1.Conditi
 	undetectedCIDRs := cidrsFromDRCluster.Difference(cidrsFromDRCC).List()
 	if len(undetectedCIDRs) > 0 {
 		setCIDRsValidatedConditionUndetectedCIDRsFound(conditions, observedGeneration,
-			fmt.Sprintf("CIDRs not detected by storage provisioner: %s", strings.Join(undetectedCIDRs, ", ")))
+			fmt.Sprintf("warning: CIDRs not detected by storage provisioner: %s", strings.Join(undetectedCIDRs, ", ")))
 
 		return nil
 	}
@@ -586,6 +586,8 @@ func (u *drclusterInstance) validateCIDRs(
 	conditions *[]metav1.Condition, observedGeneration int64,
 ) error {
 	if len(u.object.Spec.CIDRs) == 0 {
+		meta.RemoveStatusCondition(conditions, ramen.DRClusterConditionTypeCIDRsValidated)
+
 		return nil
 	}
 

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"reflect"
@@ -404,7 +405,7 @@ func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 // potentially unreachable. Fencing is to request fencing this cluster using another, hence this cluster may fail
 // other live validation checks, but we still need to process the fence request.
 //
-//nolint:cyclop
+//nolint:cyclop,funlen
 func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.Result, error) {
 	var requeue bool
 
@@ -447,9 +448,10 @@ func (r DRClusterReconciler) processCreateOrUpdate(u *drclusterInstance) (ctrl.R
 		)
 	}
 
-	if err = u.validateCIDRs(drclusterMetrics.InvalidCIDRsDetectedMetrics, u.log); err != nil {
+	if err = u.validateCIDRs(drclusterMetrics.InvalidCIDRsDetectedMetrics, u.log,
+		&u.object.Status.Conditions, u.object.Generation); err != nil {
 		return ctrl.Result{}, fmt.Errorf("drclusters CIDRs validate: %w",
-			u.validatedSetFalseAndUpdate(ReasonValidationFailed, err))
+			u.validatedSetFalseAndUpdate(ReasonValidationFailed, errors.New("CIDRs validation failed")))
 	}
 
 	setDRClusterValidatedCondition(&u.object.Status.Conditions, u.object.Generation, "Validated the cluster")
@@ -523,8 +525,8 @@ func createDRClusterMetricsInstance(drcluster *ramen.DRCluster) DRClusterMetrics
 //
 // Validation is skipped if DRClusterConfig is not found or StorageAccessDetails is empty.
 // The watch on ManagedClusterView/ManifestWork will trigger reconciliation when these
-// become available. Returns an error if any detected CIDRs are not configured.
-func (u *drclusterInstance) validateCIDRsConfigured() error {
+// become available.
+func (u *drclusterInstance) validateCIDRsConfigured(conditions *[]metav1.Condition, observedGeneration int64) error {
 	drcConfig, err := u.getDRCCFromCluster(u.object)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -553,18 +555,36 @@ func (u *drclusterInstance) validateCIDRsConfigured() error {
 
 	cidrsFromDRCluster := sets.NewString(u.object.Spec.CIDRs...)
 
+	// CIDRsValidated=False: detected CIDRs missing from DRCluster.Spec
 	unconfiguredCIDRs := cidrsFromDRCC.Difference(cidrsFromDRCluster).List()
 	if len(unconfiguredCIDRs) > 0 {
-		return fmt.Errorf("expected CIDRs not configured %s", strings.Join(unconfiguredCIDRs, ", "))
+		msg := fmt.Sprintf("detected CIDRs not configured: %s", strings.Join(unconfiguredCIDRs, ", "))
+		setCIDRsValidatedConditionDetectedCIDRsUnconfigured(conditions, observedGeneration, msg)
+
+		return fmt.Errorf("%s", msg)
 	}
 
-	// TODO: raise an alert for undetectedCIDRs (cidrsFromDRCluster.Difference(cidrsFromDRCC))
-	// to surface additional CIDRs in DRCluster that are not present in StorageAccessDetails.
+	// CIDRsValidated=True: additional CIDRs in DRCluster not detected by the storage provisioner
+	undetectedCIDRs := cidrsFromDRCluster.Difference(cidrsFromDRCC).List()
+	if len(undetectedCIDRs) > 0 {
+		setCIDRsValidatedConditionUndetectedCIDRsFound(conditions, observedGeneration,
+			fmt.Sprintf("CIDRs not detected by storage provisioner: %s", strings.Join(undetectedCIDRs, ", ")))
+
+		return nil
+	}
+
+	// CIDRsValidated=True: all detected CIDRs are configured
+	setCIDRsValidatedConditionSucceeded(conditions, observedGeneration, "All detected CIDRs are configured")
 
 	return nil
 }
 
-func (u *drclusterInstance) validateCIDRs(metrics InvalidCIDRsDetectedMetrics, log logr.Logger) error {
+// validateCIDRs validates the CIDRs configured in DRCluster.Spec. Validation is skipped
+// if no CIDRs are configured, as non-MDR setups do not use network fencing.
+func (u *drclusterInstance) validateCIDRs(
+	metrics InvalidCIDRsDetectedMetrics, log logr.Logger,
+	conditions *[]metav1.Condition, observedGeneration int64,
+) error {
 	if len(u.object.Spec.CIDRs) == 0 {
 		return nil
 	}
@@ -572,13 +592,16 @@ func (u *drclusterInstance) validateCIDRs(metrics InvalidCIDRsDetectedMetrics, l
 	err := validateCIDRsFormat(u.object, log)
 	if err != nil {
 		metrics.InvalidCIDRsDetected.Set(1)
+		setCIDRsValidatedConditionInvalidFormat(conditions, observedGeneration, err.Error())
+		log.Error(err, "CIDRs format validation failed")
 
 		return err
 	}
 
-	err = u.validateCIDRsConfigured()
+	err = u.validateCIDRsConfigured(conditions, observedGeneration)
 	if err != nil {
 		metrics.InvalidCIDRsDetected.Set(1)
+		log.Error(err, "CIDRs validation failed")
 
 		return err
 	}
@@ -1588,6 +1611,50 @@ func setDRClusterCleaningFailedCondition(conditions *[]metav1.Condition, observe
 	util.SetStatusCondition(conditions, metav1.Condition{
 		Type:               ramen.DRClusterConditionTypeClean,
 		Reason:             DRClusterConditionReasonCleanError,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+func setCIDRsValidatedConditionSucceeded(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeCIDRsValidated,
+		Reason:             ramen.ReasonCIDRsValidationSucceeded,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+func setCIDRsValidatedConditionUndetectedCIDRsFound(
+	conditions *[]metav1.Condition, observedGeneration int64, message string,
+) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeCIDRsValidated,
+		Reason:             ramen.ReasonUndetectedCIDRsFound,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionTrue,
+		Message:            message,
+	})
+}
+
+func setCIDRsValidatedConditionDetectedCIDRsUnconfigured(
+	conditions *[]metav1.Condition, observedGeneration int64, message string,
+) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeCIDRsValidated,
+		Reason:             ramen.ReasonDetectedCIDRsUnconfigured,
+		ObservedGeneration: observedGeneration,
+		Status:             metav1.ConditionFalse,
+		Message:            message,
+	})
+}
+
+func setCIDRsValidatedConditionInvalidFormat(conditions *[]metav1.Condition, observedGeneration int64, message string) {
+	util.SetStatusCondition(conditions, metav1.Condition{
+		Type:               ramen.DRClusterConditionTypeCIDRsValidated,
+		Reason:             ramen.ReasonInvalidCIDRsFormat,
 		ObservedGeneration: observedGeneration,
 		Status:             metav1.ConditionFalse,
 		Message:            message,

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -511,13 +511,20 @@ func createDRClusterMetricsInstance(drcluster *ramen.DRCluster) DRClusterMetrics
 	}
 }
 
-// validateCIDRsDetected ensures all CIDRs in DRCluster spec are detected
-// in StorageAccessDetails from DRClusterConfig status.
+// validateCIDRsConfigured ensures all detected CIDRs from DRClusterConfig StorageAccessDetails
+// are configured in the DRCluster. Additional CIDRs in DRCluster that are undetected
+// (not present in StorageAccessDetails) are allowed.
+//
+// Terminology:
+//   - detected:     CIDRs in DRClusterConfig StorageAccessDetails, auto-detected by the storage provisioner
+//   - undetected:   CIDRs in DRCluster.Spec not present in StorageAccessDetails (additional, allowed)
+//   - unconfigured: CIDRs detected by the storage provisioner but not configured in DRCluster.Spec
+//     (these cause a validation error)
 //
 // Validation is skipped if DRClusterConfig is not found or StorageAccessDetails is empty.
 // The watch on ManagedClusterView/ManifestWork will trigger reconciliation when these
-// become available. Returns an error if any CIDRs in spec are not found in the detected set.
-func (u *drclusterInstance) validateCIDRsDetected() error {
+// become available. Returns an error if any detected CIDRs are not configured.
+func (u *drclusterInstance) validateCIDRsConfigured() error {
 	drcConfig, err := u.getDRCCFromCluster(u.object)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
@@ -546,15 +553,22 @@ func (u *drclusterInstance) validateCIDRsDetected() error {
 
 	cidrsFromDRCluster := sets.NewString(u.object.Spec.CIDRs...)
 
-	undetectedCIDRs := cidrsFromDRCluster.Difference(cidrsFromDRCC).List()
-	if len(undetectedCIDRs) > 0 {
-		return fmt.Errorf("undetected CIDRs specified %s", strings.Join(undetectedCIDRs, ", "))
+	unconfiguredCIDRs := cidrsFromDRCC.Difference(cidrsFromDRCluster).List()
+	if len(unconfiguredCIDRs) > 0 {
+		return fmt.Errorf("expected CIDRs not configured %s", strings.Join(unconfiguredCIDRs, ", "))
 	}
+
+	// TODO: raise an alert for undetectedCIDRs (cidrsFromDRCluster.Difference(cidrsFromDRCC))
+	// to surface additional CIDRs in DRCluster that are not present in StorageAccessDetails.
 
 	return nil
 }
 
 func (u *drclusterInstance) validateCIDRs(metrics InvalidCIDRsDetectedMetrics, log logr.Logger) error {
+	if len(u.object.Spec.CIDRs) == 0 {
+		return nil
+	}
+
 	err := validateCIDRsFormat(u.object, log)
 	if err != nil {
 		metrics.InvalidCIDRsDetected.Set(1)
@@ -562,7 +576,7 @@ func (u *drclusterInstance) validateCIDRs(metrics InvalidCIDRsDetectedMetrics, l
 		return err
 	}
 
-	err = u.validateCIDRsDetected()
+	err = u.validateCIDRsConfigured()
 	if err != nil {
 		metrics.InvalidCIDRsDetected.Set(1)
 

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -1136,7 +1136,7 @@ var _ = Describe("DRClusterController", func() {
 			drcluster = drclusters[0].DeepCopy()
 		})
 
-		When("provided CIDRs match detected StorageAccessDetails", func() {
+		When("provided CIDRs include all expected CIDRs from StorageAccessDetails", func() {
 			It("reports validated with reason Succeeded", func() {
 				NFClassCount = 1
 
@@ -1159,13 +1159,37 @@ var _ = Describe("DRClusterController", func() {
 			})
 		})
 
-		When("provided CIDRs do not match detected StorageAccessDetails", func() {
+		When("provided CIDRs include all expected CIDRs plus additional undetected CIDRs", func() {
+			It("reports validated with reason Succeeded", func() {
+				NFClassCount = 1
+
+				defer func() { NFClassCount = 0 }()
+
+				// cidrs[0] are the detected CIDRs in StorageAccessDetails; cidrs[1] are additional undetected CIDRs
+				drcluster.Spec.CIDRs = append(cidrs[0], cidrs[1]...)
+				drcluster = updateDRClusterParameters(drcluster)
+				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
+				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
+				objectConditionExpectEventually(
+					apiReader,
+					drcluster,
+					metav1.ConditionTrue,
+					Equal(controllers.DRClusterConditionReasonValidated),
+					Ignore(),
+					ramen.DRClusterValidated,
+					false,
+				)
+			})
+		})
+
+		When("provided CIDRs do not include expected CIDRs from StorageAccessDetails", func() {
 			It("reports NOT validated with reason ValidationFailed", func() {
 				NFClassCount = 1
 
 				defer func() { NFClassCount = 0 }()
 
-				drcluster.Spec.CIDRs = []string{"192.168.1.0/24"} // CIDR not in StorageAccessDetails
+				drcluster.Spec.CIDRs = []string{"192.168.1.0/24"} // missing expected CIDRs from StorageAccessDetails
 				drcluster = updateDRClusterParameters(drcluster)
 				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
 				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
@@ -1175,7 +1199,7 @@ var _ = Describe("DRClusterController", func() {
 					drcluster,
 					metav1.ConditionFalse,
 					Equal(controllers.ReasonValidationFailed),
-					ContainSubstring("undetected CIDRs specified"),
+					ContainSubstring("expected CIDRs not configured"),
 					ramen.DRClusterValidated,
 					false,
 				)

--- a/internal/controller/drcluster_controller_test.go
+++ b/internal/controller/drcluster_controller_test.go
@@ -580,6 +580,15 @@ var _ = Describe("DRClusterController", func() {
 					ramen.DRClusterValidated,
 					false,
 				)
+				objectConditionExpectEventually(
+					apiReader,
+					drcluster,
+					metav1.ConditionFalse,
+					Equal(ramen.ReasonInvalidCIDRsFormat),
+					Ignore(),
+					ramen.DRClusterConditionTypeCIDRsValidated,
+					false,
+				)
 			})
 		})
 		When("provided CIDR value is changed to be correct", func() {
@@ -641,6 +650,15 @@ var _ = Describe("DRClusterController", func() {
 					Equal("ValidationFailed"),
 					Ignore(),
 					ramen.DRClusterValidated,
+					false,
+				)
+				objectConditionExpectEventually(
+					apiReader,
+					drcluster,
+					metav1.ConditionFalse,
+					Equal(ramen.ReasonInvalidCIDRsFormat),
+					Ignore(),
+					ramen.DRClusterConditionTypeCIDRsValidated,
 					false,
 				)
 			})
@@ -1136,7 +1154,7 @@ var _ = Describe("DRClusterController", func() {
 			drcluster = drclusters[0].DeepCopy()
 		})
 
-		When("provided CIDRs include all expected CIDRs from StorageAccessDetails", func() {
+		When("provided CIDRs include all detected CIDRs from StorageAccessDetails", func() {
 			It("reports validated with reason Succeeded", func() {
 				NFClassCount = 1
 
@@ -1156,11 +1174,20 @@ var _ = Describe("DRClusterController", func() {
 					ramen.DRClusterValidated,
 					false,
 				)
+				objectConditionExpectEventually(
+					apiReader,
+					drcluster,
+					metav1.ConditionTrue,
+					Equal(ramen.ReasonCIDRsValidationSucceeded),
+					Ignore(),
+					ramen.DRClusterConditionTypeCIDRsValidated,
+					false,
+				)
 			})
 		})
 
-		When("provided CIDRs include all expected CIDRs plus additional undetected CIDRs", func() {
-			It("reports validated with reason Succeeded", func() {
+		When("provided CIDRs include all detected CIDRs plus additional undetected CIDRs", func() {
+			It("reports validated with reason Succeeded and CIDRsValidated with reason UndetectedCIDRsFound", func() {
 				NFClassCount = 1
 
 				defer func() { NFClassCount = 0 }()
@@ -1180,30 +1207,49 @@ var _ = Describe("DRClusterController", func() {
 					ramen.DRClusterValidated,
 					false,
 				)
-			})
-		})
-
-		When("provided CIDRs do not include expected CIDRs from StorageAccessDetails", func() {
-			It("reports NOT validated with reason ValidationFailed", func() {
-				NFClassCount = 1
-
-				defer func() { NFClassCount = 0 }()
-
-				drcluster.Spec.CIDRs = []string{"192.168.1.0/24"} // missing expected CIDRs from StorageAccessDetails
-				drcluster = updateDRClusterParameters(drcluster)
-				updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
-				updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
-
 				objectConditionExpectEventually(
 					apiReader,
 					drcluster,
-					metav1.ConditionFalse,
-					Equal(controllers.ReasonValidationFailed),
-					ContainSubstring("expected CIDRs not configured"),
-					ramen.DRClusterValidated,
+					metav1.ConditionTrue,
+					Equal(ramen.ReasonUndetectedCIDRsFound),
+					ContainSubstring("CIDRs not detected by storage provisioner"),
+					ramen.DRClusterConditionTypeCIDRsValidated,
 					false,
 				)
 			})
+		})
+
+		When("provided CIDRs do not include detected CIDRs from StorageAccessDetails", func() {
+			It("reports NOT validated with reason ValidationFailed and CIDRsValidated with reason DetectedCIDRsUnconfigured",
+				func() {
+					NFClassCount = 1
+
+					defer func() { NFClassCount = 0 }()
+
+					drcluster.Spec.CIDRs = []string{"192.168.1.0/24"} // missing detected CIDRs from StorageAccessDetails
+					drcluster = updateDRClusterParameters(drcluster)
+					updateDRClusterManifestWorkStatus(k8sClient, apiReader, drcluster.Name)
+					updateDRClusterConfigMWStatus(k8sClient, apiReader, drcluster.Name)
+
+					objectConditionExpectEventually(
+						apiReader,
+						drcluster,
+						metav1.ConditionFalse,
+						Equal(controllers.ReasonValidationFailed),
+						ContainSubstring("CIDRs validation failed"),
+						ramen.DRClusterValidated,
+						false,
+					)
+					objectConditionExpectEventually(
+						apiReader,
+						drcluster,
+						metav1.ConditionFalse,
+						Equal(ramen.ReasonDetectedCIDRsUnconfigured),
+						ContainSubstring("detected CIDRs not configured"),
+						ramen.DRClusterConditionTypeCIDRsValidated,
+						false,
+					)
+				})
 		})
 
 		When("deleting a DRCluster", func() {


### PR DESCRIPTION
Flip CIDR validation to check that all detected CIDRs from
DRClusterConfig are configured in the DRCluster, rather than
requiring all configured CIDRs to be detected.
Additional CIDRs in the DRCluster are allowed but unconfigured detected
CIDRs could leave storage access paths outside the fencing scope.

Skip validation entirely when DRCluster has no CIDRs configured,
as non-MDR setups do not use fencing.

Add a new CIDRsValidated condition:

Succeeded: all detected CIDRs are configured
UndetectedCIDRsFound: additional CIDRs not detected by storage provisioner (informational, DRCluster validates)
DetectedCIDRsUnconfigured: detected CIDRs missing from DRCluster (validation failure)
InvalidCIDRsFormat: CIDRs in DRCluster.Spec have invalid format (validation failure)
Example 1:

configured=[1.1.1.1/32, 2.2.2.2/32, 3.3.3.3/32],
detected=[1.1.1.1/32, 2.2.2.2/32] => valid (extra 3.3.3.3/32 is ok)
Example 2:

configured=[1.1.1.1/32], detected=[1.1.1.1/32, 2.2.2.2/32]
=> error (detected 2.2.2.2/32 missing from spec)

Remove the CIDRsValidated condition when DRCluster.Spec.CIDRs is empty to avoid stale condition in status.
Also prefix the UndetectedCIDRsFound message with "warning:" to signal the admin's attention.